### PR TITLE
Replace \"%s\" with %q in printfs

### DIFF
--- a/git-appraise/git-appraise.go
+++ b/git-appraise/git-appraise.go
@@ -60,7 +60,7 @@ func help() {
 	}
 	subcommand, ok := commands.CommandMap[os.Args[2]]
 	if !ok {
-		fmt.Printf("Unknown command \"%s\"\n", os.Args[2])
+		fmt.Printf("Unknown command %q\n", os.Args[2])
 		usage()
 		return
 	}
@@ -82,7 +82,7 @@ func main() {
 	}
 	subcommand, ok := commands.CommandMap[os.Args[1]]
 	if !ok {
-		fmt.Printf("Unknown command \"%s\"", os.Args[1])
+		fmt.Printf("Unknown command %q", os.Args[1])
 		usage()
 		return
 	}


### PR DESCRIPTION
The %q format specifier is [defined as](https://golang.org/pkg/fmt/):
%q	a double-quoted string safely escaped with Go syntax

It essentially exists so you don't have to manually escape strings when printing them. See for yourself:
http://play.golang.org/p/zFZzzfpP1g