### PR TITLE
Small tweaks to satisfy the go lint tool

### DIFF
--- a/commands/show.go
+++ b/commands/show.go
@@ -27,7 +27,7 @@ import (
 )
 
 var showFlagSet = flag.NewFlagSet("show", flag.ExitOnError)
-var showJsonOutput = showFlagSet.Bool("json", false, "Format the output as JSON")
+var showJSONOutput = showFlagSet.Bool("json", false, "Format the output as JSON")
 var showDiffOutput = showFlagSet.Bool("diff", false, "Show the current diff for the review")
 var showDiffOptions = showFlagSet.String("diff-opts", "", "Options to pass to the diff tool; can only be used with the --diff option")
 
@@ -57,7 +57,7 @@ func showReview(repo repository.Repo, args []string) error {
 	if r == nil {
 		return errors.New("There is no matching review.")
 	}
-	if *showJsonOutput {
+	if *showJSONOutput {
 		return output.PrintJson(r)
 	}
 	if *showDiffOutput {

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -162,11 +162,11 @@ func (r mockRepoForTest) GetPath() string { return "~/mockRepo/" }
 
 // GetRepoStateHash returns a hash which embodies the entire current state of a repository.
 func (r mockRepoForTest) GetRepoStateHash() (string, error) {
-	repoJson, err := json.Marshal(r)
+	repoJSON, err := json.Marshal(r)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", sha1.Sum([]byte(repoJson))), nil
+	return fmt.Sprintf("%x", sha1.Sum([]byte(repoJSON))), nil
 }
 
 // GetUserEmail returns the email address that the user has used to configure git.

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -20,6 +20,7 @@ package repository
 // Note represents the contents of a git-note
 type Note []byte
 
+// CommitDetails represents the contents of a commit.
 type CommitDetails struct {
 	Author      string   `json:"author,omitempty"`
 	AuthorEmail string   `json:"authorEmail,omitempty"`


### PR DESCRIPTION
There are more things the lint tool picks up, however some changes would mean
making changes to parts of the public API for a package, i.e. for reviews the
lint tool suggests changing GetJson() to GetJSON().