### PR TITLE
Added error message for leaving empty comments

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -43,6 +43,9 @@ func commentOnReview(repo repository.Repo, args []string) error {
 	if *commentLgtm && *commentNmw {
 		return errors.New("You cannot combine the flags -lgtm and -nmw.")
 	}
+	if !*commentLgtm && !*commentNmw && *commentMessage == "" {
+		return errors.New("Message cannot be empty if neither the -lgtm or -nmw flag has been set.")
+	}
 	if *commentLine != 0 && *commentFile == "" {
 		return errors.New("Specifying a line number with the -l flag requires that you also specify a file name with the -f flag.")
 	}


### PR DESCRIPTION
This commit requires that for a comment, if -lgtm AND -nmw have not been set a
comment must be.

As per https://github.com/google/git-appraise/issues/8#issuecomment-165078292