### PR TITLE
Force default git editor when omitting -m

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -95,6 +95,11 @@ func (repo *GitRepo) GetUserEmail() (string, error) {
 	return repo.runGitCommand("config", "user.email")
 }
 
+// GetCoreEditor returns the name of the editor that the user has used to configure git.
+func (repo *GitRepo) GetCoreEditor() (string, error) {
+	return repo.runGitCommand("config", "core.editor")
+}
+
 // HasUncommittedChanges returns true if there are local, uncommitted changes.
 func (repo *GitRepo) HasUncommittedChanges() (bool, error) {
 	out, err := repo.runGitCommand("status", "--porcelain")

--- a/repository/git.go
+++ b/repository/git.go
@@ -97,7 +97,7 @@ func (repo *GitRepo) GetUserEmail() (string, error) {
 
 // GetCoreEditor returns the name of the editor that the user has used to configure git.
 func (repo *GitRepo) GetCoreEditor() (string, error) {
-	return repo.runGitCommand("config", "core.editor")
+	return repo.runGitCommand("var", "GIT_EDITOR")
 }
 
 // HasUncommittedChanges returns true if there are local, uncommitted changes.

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -172,6 +172,9 @@ func (r mockRepoForTest) GetRepoStateHash() (string, error) {
 // GetUserEmail returns the email address that the user has used to configure git.
 func (r mockRepoForTest) GetUserEmail() (string, error) { return "user@example.com", nil }
 
+// GetCoreEditor returns the name of the editor that the user has used to configure git.
+func (r mockRepoForTest) GetCoreEditor() (string, error) { return "vi", nil }
+
 // HasUncommittedChanges returns true if there are local, uncommitted changes.
 func (r mockRepoForTest) HasUncommittedChanges() (bool, error) { return false, nil }
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -41,6 +41,9 @@ type Repo interface {
 	// GetUserEmail returns the email address that the user has used to configure git.
 	GetUserEmail() (string, error)
 
+	// GetCoreEditor returns the name of the editor that the user has used to configure git.
+	GetCoreEditor() (string, error)
+
 	// HasUncommittedChanges returns true if there are local, uncommitted changes.
 	HasUncommittedChanges() (bool, error)
 


### PR DESCRIPTION
For review comments, the absense of the -m flag will now attempt to load the
user's default git editor.

i.e. git appraise comment c0a643ff39dd

An initial draft as discussed in #8 

I'm still not sure whether or not the file that is saved is in the most appropriate place or not. I like the idea of it being relative to the project although it could have gone in `/tmp` I suppose.