### PR TITLE
Added a reject subcommand

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -44,6 +44,7 @@ var CommandMap = map[string]*Command{
 	"list":    listCmd,
 	"pull":    pullCmd,
 	"push":    pushCmd,
+	"reject":  rejectCmd,
 	"request": requestCmd,
 	"show":    showCmd,
 	"submit":  submitCmd,

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -44,6 +44,26 @@ var (
 func commentOnReview(repo repository.Repo, args []string) error {
 	commentFlagSet.Parse(args)
 	args = commentFlagSet.Args()
+
+	var r *review.Review
+	var err error
+	if len(args) > 1 {
+		return errors.New("Only accepting a single review is supported.")
+	}
+
+	if len(args) == 1 {
+		r, err = review.Get(repo, args[0])
+	} else {
+		r, err = review.GetCurrent(repo)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to load the review: %v\n", err)
+	}
+	if r == nil {
+		return errors.New("There is no matching review.")
+	}
+
 	if *commentMessage == "" {
 		editor, err := repo.GetCoreEditor()
 		if err != nil {
@@ -79,25 +99,6 @@ func commentOnReview(repo repository.Repo, args []string) error {
 	}
 	if *commentLine != 0 && *commentFile == "" {
 		return errors.New("Specifying a line number with the -l flag requires that you also specify a file name with the -f flag.")
-	}
-
-	var r *review.Review
-	var err error
-	if len(args) > 1 {
-		return errors.New("Only accepting a single review is supported.")
-	}
-
-	if len(args) == 1 {
-		r, err = review.Get(repo, args[0])
-	} else {
-		r, err = review.GetCurrent(repo)
-	}
-
-	if err != nil {
-		return fmt.Errorf("Failed to load the review: %v\n", err)
-	}
-	if r == nil {
-		return errors.New("There is no matching review.")
 	}
 
 	commentedUponCommit, err := r.GetHeadCommit()

--- a/commands/reject.go
+++ b/commands/reject.go
@@ -40,6 +40,25 @@ func rejectReview(repo repository.Repo, args []string) error {
 	rejectFlagSet.Parse(args)
 	args = rejectFlagSet.Args()
 
+	var r *review.Review
+	var err error
+	if len(args) > 1 {
+		return errors.New("Only rejecting a single review is supported.")
+	}
+
+	if len(args) == 1 {
+		r, err = review.Get(repo, args[0])
+	} else {
+		r, err = review.GetCurrent(repo)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to load the review: %v\n", err)
+	}
+	if r == nil {
+		return errors.New("There is no matching review.")
+	}
+
 	if *rejectMessage == "" {
 		editor, err := repo.GetCoreEditor()
 		if err != nil {
@@ -69,25 +88,6 @@ func rejectReview(repo repository.Repo, args []string) error {
 		}
 		*rejectMessage = string(comment)
 		os.Remove(path)
-	}
-
-	var r *review.Review
-	var err error
-	if len(args) > 1 {
-		return errors.New("Only rejecting a single review is supported.")
-	}
-
-	if len(args) == 1 {
-		r, err = review.Get(repo, args[0])
-	} else {
-		r, err = review.GetCurrent(repo)
-	}
-
-	if err != nil {
-		return fmt.Errorf("Failed to load the review: %v\n", err)
-	}
-	if r == nil {
-		return errors.New("There is no matching review.")
 	}
 
 	rejectedCommit, err := r.GetHeadCommit()

--- a/commands/reject.go
+++ b/commands/reject.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/google/git-appraise/repository"
+	"github.com/google/git-appraise/review"
+	"github.com/google/git-appraise/review/comment"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+var rejectFlagSet = flag.NewFlagSet("reject", flag.ExitOnError)
+var rejectFilename = "APPRAISE_COMMENT_EDITMSG"
+
+var (
+	rejectMessage = rejectFlagSet.String("m", "", "Message to attach to the review")
+)
+
+// rejectReview adds an NMW comment to the current code review.
+func rejectReview(repo repository.Repo, args []string) error {
+	rejectFlagSet.Parse(args)
+	args = rejectFlagSet.Args()
+
+	if *rejectMessage == "" {
+		editor, err := repo.GetCoreEditor()
+		if err != nil {
+			return fmt.Errorf("Unable to detect default git editor: %v\n", err)
+		}
+
+		path := fmt.Sprintf("%s/.git/%s", repo.GetPath(), rejectFilename)
+
+		cmd := exec.Command(editor, path)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Start()
+		if err != nil {
+			return fmt.Errorf("Unable to start editor: %v\n", err)
+		}
+
+		err = cmd.Wait()
+		if err != nil {
+			return fmt.Errorf("Editing finished with error: %v\n", err)
+		}
+
+		comment, err := ioutil.ReadFile(path)
+		if err != nil {
+			os.Remove(path)
+			return fmt.Errorf("Error reading comment file: %v\n", err)
+		}
+		*rejectMessage = string(comment)
+		os.Remove(path)
+	}
+
+	var r *review.Review
+	var err error
+	if len(args) > 1 {
+		return errors.New("Only rejecting a single review is supported.")
+	}
+
+	if len(args) == 1 {
+		r, err = review.Get(repo, args[0])
+	} else {
+		r, err = review.GetCurrent(repo)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to load the review: %v\n", err)
+	}
+	if r == nil {
+		return errors.New("There is no matching review.")
+	}
+
+	rejectedCommit, err := r.GetHeadCommit()
+	if err != nil {
+		return err
+	}
+	location := comment.Location{
+		Commit: rejectedCommit,
+	}
+	resolved := false
+	userEmail, err := repo.GetUserEmail()
+	if err != nil {
+		return err
+	}
+	c := comment.New(userEmail, *rejectMessage)
+	c.Location = &location
+	c.Resolved = &resolved
+	return r.AddComment(c)
+}
+
+// rejectCmd defines the "reject" subcommand.
+var rejectCmd = &Command{
+	Usage: func(arg0 string) {
+		fmt.Printf("Usage: %s reject [<option>...] [<commit>]\n\nOptions:\n", arg0)
+		rejectFlagSet.PrintDefaults()
+	},
+	RunMethod: func(repo repository.Repo, args []string) error {
+		return rejectReview(repo, args)
+	},
+}


### PR DESCRIPTION
The reject subcommand adds a NMW comment to the review. Unlike
the accept subcommand, this requires a comment. The -m flag can
be passed to do this, or if no flag is passed it will open the
default git text editor.

This is what I have in mind in regards to #17 