### PR TITLE
Fixed updateThreadsStatus to modify original thread instances, rather than modifying copies

### DIFF
--- a/review/review.go
+++ b/review/review.go
@@ -82,7 +82,8 @@ func updateThreadsStatus(threads []CommentThread) *bool {
 	sort.Sort(byTimestamp(threads))
 	noUnresolved := true
 	var result *bool
-	for _, thread := range threads {
+	for i := range threads {
+		thread := &threads[i]
 		thread.updateResolvedStatus()
 		if thread.Resolved != nil {
 			noUnresolved = noUnresolved && *thread.Resolved


### PR DESCRIPTION
This is a proposed fix to #22 

`updateThreadsStatus` was not actually updating the CommentThread instances, but updating copies thereof.