### PR TITLE
Using the same constant for the comment file name

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -22,6 +22,7 @@ import (
 )
 
 const notesRefPattern = "refs/notes/devtools/*"
+const commentFilename = "APPRAISE_COMMENT_EDITMSG"
 
 // Command represents the definition of a single command.
 type Command struct {

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -27,7 +27,6 @@ import (
 )
 
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
-var commentFilename = "APPRAISE_COMMENT_EDITMSG"
 
 var (
 	commentMessage = commentFlagSet.String("m", "", "Message to attach to the review")

--- a/commands/reject.go
+++ b/commands/reject.go
@@ -27,7 +27,6 @@ import (
 )
 
 var rejectFlagSet = flag.NewFlagSet("reject", flag.ExitOnError)
-var rejectFilename = "APPRAISE_COMMENT_EDITMSG"
 
 var (
 	rejectMessage = rejectFlagSet.String("m", "", "Message to attach to the review")
@@ -58,7 +57,7 @@ func rejectReview(repo repository.Repo, args []string) error {
 	}
 
 	if *rejectMessage == "" {
-		*rejectMessage, err = input.LaunchEditor(repo, rejectFilename)
+		*rejectMessage, err = input.LaunchEditor(repo, commentFilename)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This isn't really a big deal, it was just bugging me from when I first
wrote it. Tidies the code up a bit and means we don't have to declare
the file name twice.