### PR TITLE
Implemented a way to configure submissions

### DIFF
--- a/commands/submit.go
+++ b/commands/submit.go
@@ -89,6 +89,18 @@ func submitReview(repo repository.Repo, args []string) error {
 	if err := repo.SwitchToRef(target); err != nil {
 		return err
 	}
+
+	mergeStrategy, err := repo.GetMergeStrategy()
+	if err != nil {
+		return err
+	}
+	if mergeStrategy == "merge" {
+		*submitMerge = true
+	}
+	if mergeStrategy == "rebase" {
+		*submitRebase = true
+	}
+
 	if *submitMerge {
 		submitMessage := fmt.Sprintf("Submitting review %.12s", r.Revision)
 		return repo.MergeRef(source, false, submitMessage, r.Request.Description)

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -94,10 +94,10 @@ func submitReview(repo repository.Repo, args []string) error {
 	if err != nil {
 		return err
 	}
-	if mergeStrategy == "merge" {
+	if mergeStrategy == "merge" && !*submitRebase {
 		*submitMerge = true
 	}
-	if mergeStrategy == "rebase" {
+	if mergeStrategy == "rebase" && !*submitMerge {
 		*submitRebase = true
 	}
 

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -27,9 +27,10 @@ import (
 var submitFlagSet = flag.NewFlagSet("submit", flag.ExitOnError)
 
 var (
-	submitMerge  = submitFlagSet.Bool("merge", false, "Create a merge of the source and target refs.")
-	submitRebase = submitFlagSet.Bool("rebase", false, "Rebase the source ref onto the target ref.")
-	submitTBR    = submitFlagSet.Bool("tbr", false, "(To be reviewed) Force the submission of a review that has not been accepted.")
+	submitMerge       = submitFlagSet.Bool("merge", false, "Create a merge of the source and target refs.")
+	submitRebase      = submitFlagSet.Bool("rebase", false, "Rebase the source ref onto the target ref.")
+	submitFastForward = submitFlagSet.Bool("fast-forward", false, "Create a merge using the default fast-forward mode.")
+	submitTBR         = submitFlagSet.Bool("tbr", false, "(To be reviewed) Force the submission of a review that has not been accepted.")
 )
 
 // Submit the current code review request.
@@ -90,15 +91,18 @@ func submitReview(repo repository.Repo, args []string) error {
 		return err
 	}
 
-	mergeStrategy, err := repo.GetMergeStrategy()
+	submitStrategy, err := repo.GetSubmitStrategy()
 	if err != nil {
 		return err
 	}
-	if mergeStrategy == "merge" && !*submitRebase {
+	if submitStrategy == "merge" && !*submitRebase && !*submitFastForward {
 		*submitMerge = true
 	}
-	if mergeStrategy == "rebase" && !*submitMerge {
+	if submitStrategy == "rebase" && !*submitMerge && !*submitFastForward {
 		*submitRebase = true
+	}
+	if submitStrategy == "fast-forward" && !*submitRebase && !*submitMerge {
+		*submitFastForward = true
 	}
 
 	if *submitMerge {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -91,18 +91,20 @@ func submitReview(repo repository.Repo, args []string) error {
 		return err
 	}
 
-	submitStrategy, err := repo.GetSubmitStrategy()
-	if err != nil {
-		return err
-	}
-	if submitStrategy == "merge" && !*submitRebase && !*submitFastForward {
-		*submitMerge = true
-	}
-	if submitStrategy == "rebase" && !*submitMerge && !*submitFastForward {
-		*submitRebase = true
-	}
-	if submitStrategy == "fast-forward" && !*submitRebase && !*submitMerge {
-		*submitFastForward = true
+	if !(*submitRebase || *submitMerge || *submitFastForward) {
+		submitStrategy, err := repo.GetSubmitStrategy()
+		if err != nil {
+			return err
+		}
+		if submitStrategy == "merge" && !*submitRebase && !*submitFastForward {
+			*submitMerge = true
+		}
+		if submitStrategy == "rebase" && !*submitMerge && !*submitFastForward {
+			*submitRebase = true
+		}
+		if submitStrategy == "fast-forward" && !*submitRebase && !*submitMerge {
+			*submitFastForward = true
+		}
 	}
 
 	if *submitMerge {

--- a/repository/git.go
+++ b/repository/git.go
@@ -103,9 +103,10 @@ func (repo *GitRepo) GetCoreEditor() (string, error) {
 	return repo.runGitCommand("var", "GIT_EDITOR")
 }
 
-// GetMergeStrategy returns the way in which a submitted review is merged
-func (repo *GitRepo) GetMergeStrategy() (string, error) {
-	return repo.runGitCommand("config", "appraise.submit")
+// GetSubmitStrategy returns the way in which a review is submitted
+func (repo *GitRepo) GetSubmitStrategy() (string, error) {
+	submitStrategy, _ := repo.runGitCommand("config", "appraise.submit")
+	return submitStrategy, nil
 }
 
 // HasUncommittedChanges returns true if there are local, uncommitted changes.

--- a/repository/git.go
+++ b/repository/git.go
@@ -100,6 +100,11 @@ func (repo *GitRepo) GetCoreEditor() (string, error) {
 	return repo.runGitCommand("var", "GIT_EDITOR")
 }
 
+// GetMergeStrategy returns the way in which a submitted review is merged
+func (repo *GitRepo) GetMergeStrategy() (string, error) {
+	return repo.runGitCommand("config", "appraise.submit")
+}
+
 // HasUncommittedChanges returns true if there are local, uncommitted changes.
 func (repo *GitRepo) HasUncommittedChanges() (bool, error) {
 	out, err := repo.runGitCommand("status", "--porcelain")

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -180,6 +180,9 @@ func (r mockRepoForTest) GetUserEmail() (string, error) { return "user@example.c
 // GetCoreEditor returns the name of the editor that the user has used to configure git.
 func (r mockRepoForTest) GetCoreEditor() (string, error) { return "vi", nil }
 
+// GetMergeStrategy returns the way in which a submitted review is merged
+func (r mockRepoForTest) GetMergeStrategy() (string, error) { return "merge", nil }
+
 // HasUncommittedChanges returns true if there are local, uncommitted changes.
 func (r mockRepoForTest) HasUncommittedChanges() (bool, error) { return false, nil }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -180,8 +180,8 @@ func (r mockRepoForTest) GetUserEmail() (string, error) { return "user@example.c
 // GetCoreEditor returns the name of the editor that the user has used to configure git.
 func (r mockRepoForTest) GetCoreEditor() (string, error) { return "vi", nil }
 
-// GetMergeStrategy returns the way in which a submitted review is merged
-func (r mockRepoForTest) GetMergeStrategy() (string, error) { return "merge", nil }
+// GetSubmitStrategy returns the way in which a review is submitted
+func (r mockRepoForTest) GetSubmitStrategy() (string, error) { return "merge", nil }
 
 // HasUncommittedChanges returns true if there are local, uncommitted changes.
 func (r mockRepoForTest) HasUncommittedChanges() (bool, error) { return false, nil }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -44,6 +44,9 @@ type Repo interface {
 	// GetCoreEditor returns the name of the editor that the user has used to configure git.
 	GetCoreEditor() (string, error)
 
+	// GetMergeStrategy returns the way in which a submitted review is merged
+	GetMergeStrategy() (string, error)
+
 	// HasUncommittedChanges returns true if there are local, uncommitted changes.
 	HasUncommittedChanges() (bool, error)
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -44,8 +44,8 @@ type Repo interface {
 	// GetCoreEditor returns the name of the editor that the user has used to configure git.
 	GetCoreEditor() (string, error)
 
-	// GetMergeStrategy returns the way in which a submitted review is merged
-	GetMergeStrategy() (string, error)
+	// GetSubmitStrategy returns the way in which a review is submitted
+	GetSubmitStrategy() (string, error)
 
 	// HasUncommittedChanges returns true if there are local, uncommitted changes.
 	HasUncommittedChanges() (bool, error)


### PR DESCRIPTION
I've made a start on what you suggested in #35. It seems to work
as expected. Adding a --merge flag when git is configured to rebase for example
will overwrite the rebase configuration.

This will fallback to 'merge' by default as I believe it did before.

Is this the kind of thing you were after?