### PR TITLE
Fix line-number

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -58,7 +58,7 @@ func checkCommentLocation(repo repository.Repo, commit, file string, line uint) 
 		return err
 	}
 	lines := strings.Split(contents, "\n")
-	if line >= uint(len(lines)) {
+	if line > uint(len(lines)) {
 		return fmt.Errorf("Line number %d does not exist in file %q", line, file)
 	}
 	return nil


### PR DESCRIPTION
```
$ git appraise comment -m test -f README.md -l 1 b2a042b3773555f73aef5a840289b3ca110612de
Unabled to comment on the given location: Line number 1 does not exist in file "README.md"
```
line-number should be started from 1.