### PR TITLE
Add optional CI output to note

### DIFF
--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -20,6 +20,7 @@ package output
 import (
 	"fmt"
 	"github.com/google/git-appraise/review"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -152,6 +153,13 @@ func printAnalyses(r *review.Review) {
 	fmt.Println("  analyses: ", r.GetAnalysesMessage())
 }
 
+// printBuildStatusOutput prints the static analysis results for the latest commit in the review.
+func printBuildStatusOutput(r *review.Review) {
+	indent := "    "
+	indentRegex := regexp.MustCompile("\n")
+	fmt.Println(indent + indentRegex.ReplaceAllString(r.GetBuildStatusOutput(), "\n"+indent))
+}
+
 // printComments prints all of the comments for the review, with snippets of the preceding source code.
 func printComments(r *review.Review) error {
 	fmt.Printf(commentSummaryTemplate, len(r.Comments))
@@ -170,6 +178,7 @@ func PrintDetails(r *review.Review) error {
 	fmt.Printf(reviewDetailsTemplate, r.Request.ReviewRef, r.Request.TargetRef,
 		strings.Join(r.Request.Reviewers, ", "),
 		r.Request.Requester, r.GetBuildStatusMessage())
+	printBuildStatusOutput(r)
 	printAnalyses(r)
 	if err := printComments(r); err != nil {
 		return err

--- a/review/ci/ci.go
+++ b/review/ci/ci.go
@@ -45,6 +45,7 @@ type Report struct {
 	URL       string `json:"url,omitempty"`
 	Status    string `json:"status,omitempty"`
 	Agent     string `json:"agent,omitempty"`
+	Output    string `json:"output,omitempty"`
 	// Version represents the version of the metadata format.
 	Version int `json:"v,omitempty"`
 }

--- a/review/ci/ci_test.go
+++ b/review/ci/ci_test.go
@@ -51,6 +51,12 @@ const testCINote5 = `{
 	"Status": "success"
 }`
 
+const testCINote6 = `{
+	"Timestamp": "27",
+	"Status": "success"
+	"Output": "biz\nbaz"
+}`
+
 func TestCIReport(t *testing.T) {
 	latestReport, err := GetLatestCIReport(ParseAllValid([]repository.Note{
 		repository.Note(testCINote1),
@@ -71,6 +77,7 @@ func TestCIReport(t *testing.T) {
 		repository.Note(testCINote2),
 		repository.Note(testCINote3),
 		repository.Note(testCINote4),
+		repository.Note(testCINote6),
 	}))
 	if err != nil {
 		t.Fatal("Failed to properly fetch the latest report", err)

--- a/review/review.go
+++ b/review/review.go
@@ -315,6 +315,20 @@ func (r *Review) GetBuildStatusMessage() string {
 	return statusMessage
 }
 
+// GetBuildStatusOutput returns a string of the current build-and-test output
+// of the review, or "unknown" if the build-and-test output cannot be determined.
+func (r *Review) GetBuildStatusOutput() string {
+	statusOutput := ""
+	ciReport, err := ci.GetLatestCIReport(r.Reports)
+	if err != nil {
+		return fmt.Sprintf("unknown: %s", err)
+	}
+	if ciReport != nil {
+		statusOutput = ciReport.Output
+	}
+	return statusOutput
+}
+
 // GetAnalysesNotes returns all of the notes from the most recent static
 // analysis run recorded in the git notes.
 func (r *Review) GetAnalysesNotes() ([]analyses.Note, error) {

--- a/schema/ci.json
+++ b/schema/ci.json
@@ -29,6 +29,10 @@
       "type": "string"
     },
 
+    "output": {
+      "type": "string"
+    },
+
     "v": {
       "type": "integer",
       "enum": [0]


### PR DESCRIPTION
Instead of pulling CI output from a URL, add the ability to directly
include the output in the note. This ensures the historial output is
always available.