### PR TITLE
git-appraise without subcommand will list reviews

### DIFF
--- a/git-appraise/git-appraise.go
+++ b/git-appraise/git-appraise.go
@@ -68,14 +68,6 @@ func help() {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		usage()
-		return
-	}
-	if os.Args[1] == "help" {
-		help()
-		return
-	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Printf("Unable to get the current working directory: %q\n", err)
@@ -84,6 +76,19 @@ func main() {
 	repo, err := repository.NewGitRepo(cwd)
 	if err != nil {
 		fmt.Printf("%s must be run from within a git repo.\n", os.Args[0])
+		return
+	}
+	if len(os.Args) < 2 {
+		subcommand, ok := commands.CommandMap["list"]
+		if !ok {
+			fmt.Printf("Unable to list reviews")
+			return
+		}
+		subcommand.Run(repo, []string{})
+		return
+	}
+	if os.Args[1] == "help" {
+		help()
 		return
 	}
 	subcommand, ok := commands.CommandMap[os.Args[1]]

--- a/git-appraise/git-appraise.go
+++ b/git-appraise/git-appraise.go
@@ -68,6 +68,10 @@ func help() {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "help" {
+		help()
+		return
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Printf("Unable to get the current working directory: %q\n", err)
@@ -85,10 +89,6 @@ func main() {
 			return
 		}
 		subcommand.Run(repo, []string{})
-		return
-	}
-	if os.Args[1] == "help" {
-		help()
 		return
 	}
 	subcommand, ok := commands.CommandMap[os.Args[1]]


### PR DESCRIPTION
As stated in #42, this will now show open reviews and not the usage text.
I'm still a little unsure about this, because the list command is obviously
still there and will work with flags, -a and --json for example.

Should this (non-subcommand version) allow the same, and if so, do we even need
the list subcommand?

/cc @jishi9 