### PR TITLE
Accepting -F flag on git-appraise comments

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,7 +30,7 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. se - to read the message from the standard input")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. Use - to read the message from the standard input")
 	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
 	commentParent      = commentFlagSet.String("p", "", "Parent comment")
 	commentFile        = commentFlagSet.String("f", "", "File being commented upon")

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,12 +30,13 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessage = commentFlagSet.String("m", "", "Message to attach to the review")
-	commentParent  = commentFlagSet.String("p", "", "Parent comment")
-	commentFile    = commentFlagSet.String("f", "", "File being commented upon")
-	commentLine    = commentFlagSet.Uint("l", 0, "Line being commented upon; requires that the -f flag also be set")
-	commentLgtm    = commentFlagSet.Bool("lgtm", false, "'Looks Good To Me'. Set this to express your approval. This cannot be combined with nmw")
-	commentNmw     = commentFlagSet.Bool("nmw", false, "'Needs More Work'. Set this to express your disapproval. This cannot be combined with lgtm")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. se - to read the message from the standard input")
+	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
+	commentParent      = commentFlagSet.String("p", "", "Parent comment")
+	commentFile        = commentFlagSet.String("f", "", "File being commented upon")
+	commentLine        = commentFlagSet.Uint("l", 0, "Line being commented upon; requires that the -f flag also be set")
+	commentLgtm        = commentFlagSet.Bool("lgtm", false, "'Looks Good To Me'. Set this to express your approval. This cannot be combined with nmw")
+	commentNmw         = commentFlagSet.Bool("nmw", false, "'Needs More Work'. Set this to express your disapproval. This cannot be combined with lgtm")
 )
 
 // commentHashExists checks if the given comment hash exists in the given comment threads.
@@ -98,7 +99,13 @@ func commentOnReview(repo repository.Repo, args []string) error {
 		return errors.New("There is no matching parent comment.")
 	}
 
-	if *commentMessage == "" {
+	if *commentMessageFile != "" && *commentMessage == "" {
+		*commentMessage, err = input.FromFile(*commentMessageFile)
+		if err != nil {
+			return err
+		}
+	}
+	if *commentMessageFile == "" && *commentMessage == "" {
 		*commentMessage, err = input.LaunchEditor(repo, commentFilename)
 		if err != nil {
 			return err

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,7 +30,7 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. Use - to read the message from the standard input")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file.")
 	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
 	commentParent      = commentFlagSet.String("p", "", "Parent comment")
 	commentFile        = commentFlagSet.String("f", "", "File being commented upon")

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -70,6 +70,15 @@ func LaunchEditor(repo repository.Repo, fileName string) (string, error) {
 	return string(output), err
 }
 
+// FromFile loads and returns the contents of a given file.
+func FromFile(fileName string) (string, error) {
+	output, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf("Error reading file: %v\n", err)
+	}
+	return string(output), err
+}
+
 func startInlineCommand(command string, args ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(command, args...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
I've gathered a few thoughts in regards to #56 in the form of this commit. This
currently doesn't take in to account stdin (-), just a file name.

Basically, the user has 3 choices as this point:

  - 1 git appraise comment -m "nice code!" HASH
  - 2 git appraise comment HASH
  - 3 git appraise comment -F message HASH

Given that 'message' is the file name that contains the message. As for the
stdin, keeping that similar to git would be a good idea. They present the user
with the following output and then read:

```
if (isatty(0))
    fprintf(stderr, _("(reading log message from standard input)\n"));
read_from_stdin(&log);
```

This would be consistent and imo seems like it could work well. I agree with
@ojarjur in that this should be supported with accept, comment, reject
and request. This commit only takes into account, comment. Once that's nailed
down, applying it to the rest would be trivial.