### PR TITLE
Allowing stdin in the case of comment -F

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,7 +30,7 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. se - to read the message from the standard input")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. Use - to read the message from the standard input")
 	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
 	commentParent      = commentFlagSet.String("p", "", "Parent comment")
 	commentFile        = commentFlagSet.String("f", "", "File being commented upon")

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,7 +30,7 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file.")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. Use - to read the message from the standard input")
 	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
 	commentParent      = commentFlagSet.String("p", "", "Parent comment")
 	commentFile        = commentFlagSet.String("f", "", "File being commented upon")

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,12 +30,13 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessage = commentFlagSet.String("m", "", "Message to attach to the review")
-	commentParent  = commentFlagSet.String("p", "", "Parent comment")
-	commentFile    = commentFlagSet.String("f", "", "File being commented upon")
-	commentLine    = commentFlagSet.Uint("l", 0, "Line being commented upon; requires that the -f flag also be set")
-	commentLgtm    = commentFlagSet.Bool("lgtm", false, "'Looks Good To Me'. Set this to express your approval. This cannot be combined with nmw")
-	commentNmw     = commentFlagSet.Bool("nmw", false, "'Needs More Work'. Set this to express your disapproval. This cannot be combined with lgtm")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. se - to read the message from the standard input")
+	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
+	commentParent      = commentFlagSet.String("p", "", "Parent comment")
+	commentFile        = commentFlagSet.String("f", "", "File being commented upon")
+	commentLine        = commentFlagSet.Uint("l", 0, "Line being commented upon; requires that the -f flag also be set")
+	commentLgtm        = commentFlagSet.Bool("lgtm", false, "'Looks Good To Me'. Set this to express your approval. This cannot be combined with nmw")
+	commentNmw         = commentFlagSet.Bool("nmw", false, "'Needs More Work'. Set this to express your disapproval. This cannot be combined with lgtm")
 )
 
 // commentHashExists checks if the given comment hash exists in the given comment threads.
@@ -98,7 +99,13 @@ func commentOnReview(repo repository.Repo, args []string) error {
 		return errors.New("There is no matching parent comment.")
 	}
 
-	if *commentMessage == "" {
+	if *commentMessageFile != "" && *commentMessage == "" {
+		*commentMessage, err = input.FromFile(*commentMessageFile)
+		if err != nil {
+			return err
+		}
+	}
+	if *commentMessageFile == "" && *commentMessage == "" {
 		*commentMessage, err = input.LaunchEditor(repo, commentFilename)
 		if err != nil {
 			return err

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -30,7 +30,7 @@ import (
 var commentFlagSet = flag.NewFlagSet("comment", flag.ExitOnError)
 
 var (
-	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file. Use - to read the message from the standard input")
+	commentMessageFile = commentFlagSet.String("F", "", "Take the comment from the given file.")
 	commentMessage     = commentFlagSet.String("m", "", "Message to attach to the review")
 	commentParent      = commentFlagSet.String("p", "", "Parent comment")
 	commentFile        = commentFlagSet.String("f", "", "File being commented upon")

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -93,6 +93,7 @@ func FromFile(fileName string) (string, error) {
 		s := bufio.NewScanner(os.Stdin)
 		for s.Scan() {
 			output.Write(s.Bytes())
+			output.WriteRune('\n')
 		}
 		return output.String(), nil
 	}

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -88,7 +88,7 @@ func FromFile(fileName string) (string, error) {
 			return string(output), err
 		}
 
-		fmt.Printf("(reading log message from standard input)\n")
+		fmt.Printf("(reading comment from standard input)\n")
 		var output bytes.Buffer
 		s := bufio.NewScanner(os.Stdin)
 		for s.Scan() {

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -70,6 +70,15 @@ func LaunchEditor(repo repository.Repo, fileName string) (string, error) {
 	return string(output), err
 }
 
+// FromFile loads and returns the contents of a given file.
+func FromFile(fileName string) (string, error) {
+	output, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf("Error reading file: %v\n", err)
+	}
+	return string(output), err
+}
+
 func startInlineCommand(command string, args ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(command, args...)
 	cmd.Stdin = os.Stdin

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -17,6 +17,8 @@ limitations under the License.
 package input
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"github.com/google/git-appraise/repository"
 	"io/ioutil"
@@ -70,8 +72,31 @@ func LaunchEditor(repo repository.Repo, fileName string) (string, error) {
 	return string(output), err
 }
 
-// FromFile loads and returns the contents of a given file.
+// FromFile loads and returns the contents of a given file. If - is passed
+// through, much like git, it will read from stdin. This can be piped data,
+// unless there is a tty in which case the user will be prompted to enter a
+// message.
 func FromFile(fileName string) (string, error) {
+	if fileName == "-" {
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			// There is no tty. This will allow us to read piped data instead.
+			output, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return "", fmt.Errorf("Error reading from stdin: %v\n", err)
+			}
+			return string(output), err
+		}
+
+		fmt.Printf("(reading log message from standard input)\n")
+		var output bytes.Buffer
+		s := bufio.NewScanner(os.Stdin)
+		for s.Scan() {
+			output.Write(s.Bytes())
+		}
+		return output.String(), nil
+	}
+
 	output, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return "", fmt.Errorf("Error reading file: %v\n", err)

--- a/commands/request_test.go
+++ b/commands/request_test.go
@@ -23,7 +23,10 @@ import (
 func TestBuildRequestFromFlags(t *testing.T) {
 	args := []string{"-m", "Request message", "-r", "Me, Myself, \nAnd I "}
 	requestFlagSet.Parse(args)
-	r := buildRequestFromFlags("user@hostname.com")
+	r, err := buildRequestFromFlags("user@hostname.com")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if r.Description != "Request message" {
 		t.Fatalf("Unexpected request description: '%s'", r.Description)
 	}


### PR DESCRIPTION
As mentioned in #56, passing - for stdin with -F will now read. This is
partially inspired by how git approaches this issue. Here are a couple of
examples of how comments can be made as of this commit:

```
echo 'hello!' | git appraise comment -F - HASH

git appraise comment -F - HASH
(reading comment from standard input)
hello!
```

(ctrl+D to exit from the attached version)
Feedback / thoughts would be appreciated! :)