### PR TITLE
Better support for rebasing reviews

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -23,7 +23,6 @@ import (
 
 const notesRefPattern = "refs/notes/devtools/*"
 const archiveRefPattern = "refs/devtools/archives/*"
-const archiveRef = "refs/devtools/archives/reviews"
 const commentFilename = "APPRAISE_COMMENT_EDITMSG"
 
 // Command represents the definition of a single command.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -22,6 +22,7 @@ import (
 )
 
 const notesRefPattern = "refs/notes/devtools/*"
+const archiveRef = "refs/archives/devtools"
 const commentFilename = "APPRAISE_COMMENT_EDITMSG"
 
 // Command represents the definition of a single command.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -22,6 +22,7 @@ import (
 )
 
 const notesRefPattern = "refs/notes/devtools/*"
+const archiveRefPattern = "refs/archives/*"
 const archiveRef = "refs/archives/devtools"
 const commentFilename = "APPRAISE_COMMENT_EDITMSG"
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -46,6 +46,7 @@ var CommandMap = map[string]*Command{
 	"list":    listCmd,
 	"pull":    pullCmd,
 	"push":    pushCmd,
+	"rebase":  rebaseCmd,
 	"reject":  rejectCmd,
 	"request": requestCmd,
 	"show":    showCmd,

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -22,8 +22,8 @@ import (
 )
 
 const notesRefPattern = "refs/notes/devtools/*"
-const archiveRefPattern = "refs/archives/*"
-const archiveRef = "refs/archives/devtools"
+const archiveRefPattern = "refs/devtools/archives/*"
+const archiveRef = "refs/devtools/archives/reviews"
 const commentFilename = "APPRAISE_COMMENT_EDITMSG"
 
 // Command represents the definition of a single command.

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -33,10 +33,7 @@ func pull(repo repository.Repo, args []string) error {
 		remote = args[0]
 	}
 
-	if err := repo.PullNotes(remote, notesRefPattern); err != nil {
-		return err
-	}
-	if err := repo.PullArchive(remote, archiveRef, archiveRefPattern); err != nil {
+	if err := repo.PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern); err != nil {
 		return err
 	}
 	return nil

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -36,7 +36,7 @@ func pull(repo repository.Repo, args []string) error {
 	if err := repo.PullNotes(remote, notesRefPattern); err != nil {
 		return err
 	}
-	if err := repo.PullArchive(remote, archiveRef); err != nil {
+	if err := repo.PullArchive(remote, archiveRef, archiveRefPattern); err != nil {
 		return err
 	}
 	return nil

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -33,7 +33,12 @@ func pull(repo repository.Repo, args []string) error {
 		remote = args[0]
 	}
 
-	repo.PullNotes(remote, notesRefPattern)
+	if err := repo.PullNotes(remote, notesRefPattern); err != nil {
+		return err
+	}
+	if err := repo.PullArchive(remote, archiveRef); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/commands/push.go
+++ b/commands/push.go
@@ -36,7 +36,7 @@ func push(repo repository.Repo, args []string) error {
 	if err := repo.PushNotes(remote, notesRefPattern); err != nil {
 		return err
 	}
-	if err := repo.PushArchive(remote, archiveRef); err != nil {
+	if err := repo.PushArchive(remote, archiveRefPattern); err != nil {
 		return err
 	}
 	return nil

--- a/commands/push.go
+++ b/commands/push.go
@@ -33,7 +33,13 @@ func push(repo repository.Repo, args []string) error {
 		remote = args[0]
 	}
 
-	return repo.PushNotes(remote, notesRefPattern)
+	if err := repo.PushNotes(remote, notesRefPattern); err != nil {
+		return err
+	}
+	if err := repo.PushArchive(remote, archiveRef); err != nil {
+		return err
+	}
+	return nil
 }
 
 var pushCmd = &Command{

--- a/commands/push.go
+++ b/commands/push.go
@@ -33,10 +33,7 @@ func push(repo repository.Repo, args []string) error {
 		remote = args[0]
 	}
 
-	if err := repo.PushNotes(remote, notesRefPattern); err != nil {
-		return err
-	}
-	if err := repo.PushArchive(remote, archiveRefPattern); err != nil {
+	if err := repo.PushNotesAndArchive(remote, notesRefPattern, archiveRefPattern); err != nil {
 		return err
 	}
 	return nil

--- a/commands/rebase.go
+++ b/commands/rebase.go
@@ -75,7 +75,7 @@ func rebaseReview(repo repository.Repo, args []string) error {
 	if err != nil {
 		return err
 	}
-	return r.Rebase(*submitArchive)
+	return r.Rebase(*rebaseArchive)
 }
 
 // rebaseCmd defines the "rebase" subcommand.

--- a/commands/rebase.go
+++ b/commands/rebase.go
@@ -81,7 +81,7 @@ func rebaseReview(repo repository.Repo, args []string) error {
 // rebaseCmd defines the "rebase" subcommand.
 var rebaseCmd = &Command{
 	Usage: func(arg0 string) {
-		fmt.Printf("Usage: %s rebase [<option>...]\n\nOptions:\n", arg0)
+		fmt.Printf("Usage: %s rebase [<option>...] [<review-hash>]\n\nOptions:\n", arg0)
 		rebaseFlagSet.PrintDefaults()
 	},
 	RunMethod: func(repo repository.Repo, args []string) error {

--- a/commands/rebase.go
+++ b/commands/rebase.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/google/git-appraise/repository"
+	"github.com/google/git-appraise/review"
+	"github.com/google/git-appraise/review/request"
+)
+
+var rebaseFlagSet = flag.NewFlagSet("rebase", flag.ExitOnError)
+
+var (
+	rebaseArchive = rebaseFlagSet.Bool("archive", true, "Prevent the original commit from being garbage collected.")
+)
+
+// Rebase the current code review.
+//
+// The "args" parameter contains all of the command line arguments that followed the subcommand.
+func rebaseReview(repo repository.Repo, args []string) error {
+	rebaseFlagSet.Parse(args)
+	args = rebaseFlagSet.Args()
+
+	var r *review.Review
+	var err error
+	if len(args) > 1 {
+		return errors.New("Only rebasing a single review is supported.")
+	}
+	if len(args) == 1 {
+		r, err = review.Get(repo, args[0])
+	} else {
+		r, err = review.GetCurrent(repo)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to load the review: %v\n", err)
+	}
+	if r == nil {
+		return errors.New("There is no matching review.")
+	}
+
+	if r.Submitted {
+		return errors.New("The review has already been submitted.")
+	}
+
+	target := r.Request.TargetRef
+	if err := repo.VerifyGitRef(target); err != nil {
+		return err
+	}
+	source, err := r.GetHeadCommit()
+	if err != nil {
+		return err
+	}
+	if *rebaseArchive {
+		if err := repo.ArchiveRef(source, archiveRef); err != nil {
+			return err
+		}
+	}
+	if err := repo.RebaseRef(target); err != nil {
+		return err
+	}
+	source, err = r.GetHeadCommit()
+	if err != nil {
+		return err
+	}
+
+	r.Request.Alias = source
+	newNote, err := r.Request.Write()
+	if err != nil {
+		return err
+	}
+	repo.AppendNote(request.Ref, r.Revision, newNote)
+	return nil
+}
+
+// rebaseCmd defines the "rebase" subcommand.
+var rebaseCmd = &Command{
+	Usage: func(arg0 string) {
+		fmt.Printf("Usage: %s rebase [<option>...]\n\nOptions:\n", arg0)
+		rebaseFlagSet.PrintDefaults()
+	},
+	RunMethod: func(repo repository.Repo, args []string) error {
+		return rebaseReview(repo, args)
+	},
+}

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/google/git-appraise/repository"
 	"github.com/google/git-appraise/review"
+	"github.com/google/git-appraise/review/request"
 )
 
 var submitFlagSet = flag.NewFlagSet("submit", flag.ExitOnError)
@@ -117,6 +118,13 @@ func submitReview(repo repository.Repo, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		r.Request.Alias = source
+		newNote, err := r.Request.Write()
+		if err != nil {
+			return err
+		}
+		repo.AppendNote(request.Ref, r.Revision, newNote)
 	}
 
 	if err := repo.SwitchToRef(target); err != nil {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/google/git-appraise/repository"
 	"github.com/google/git-appraise/review"
-	"github.com/google/git-appraise/review/request"
 )
 
 var submitFlagSet = flag.NewFlagSet("submit", flag.ExitOnError)
@@ -106,25 +105,13 @@ func submitReview(repo repository.Repo, args []string) error {
 	}
 
 	if *submitRebase {
-		if *submitArchive {
-			if err := repo.ArchiveRef(source, archiveRef); err != nil {
-				return err
-			}
-		}
-		if err := repo.RebaseRef(target); err != nil {
+		if err := r.Rebase(*submitArchive); err != nil {
 			return err
 		}
 		source, err = r.GetHeadCommit()
 		if err != nil {
 			return err
 		}
-
-		r.Request.Alias = source
-		newNote, err := r.Request.Write()
-		if err != nil {
-			return err
-		}
-		repo.AppendNote(request.Ref, r.Revision, newNote)
 	}
 
 	if err := repo.SwitchToRef(target); err != nil {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -128,7 +128,7 @@ func submitReview(repo repository.Repo, args []string) error {
 // submitCmd defines the "submit" subcommand.
 var submitCmd = &Command{
 	Usage: func(arg0 string) {
-		fmt.Printf("Usage: %s submit [<option>...]\n\nOptions:\n", arg0)
+		fmt.Printf("Usage: %s submit [<option>...] [<review-hash>]\n\nOptions:\n", arg0)
 		submitFlagSet.PrintDefaults()
 	},
 	RunMethod: func(repo repository.Repo, args []string) error {

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -31,6 +31,7 @@ var (
 	submitRebase      = submitFlagSet.Bool("rebase", false, "Rebase the source ref onto the target ref.")
 	submitFastForward = submitFlagSet.Bool("fast-forward", false, "Create a merge using the default fast-forward mode.")
 	submitTBR         = submitFlagSet.Bool("tbr", false, "(To be reviewed) Force the submission of a review that has not been accepted.")
+	submitArchive     = submitFlagSet.Bool("archive", true, "Prevent the original commit from being garbage collected; only affects rebased submits.")
 )
 
 // Submit the current code review request.
@@ -87,10 +88,6 @@ func submitReview(repo repository.Repo, args []string) error {
 		return errors.New("Refusing to submit a non-fast-forward review. First merge the target ref.")
 	}
 
-	if err := repo.SwitchToRef(target); err != nil {
-		return err
-	}
-
 	if !(*submitRebase || *submitMerge || *submitFastForward) {
 		submitStrategy, err := repo.GetSubmitStrategy()
 		if err != nil {
@@ -107,11 +104,27 @@ func submitReview(repo repository.Repo, args []string) error {
 		}
 	}
 
+	if *submitRebase {
+		if *submitArchive {
+			if err := repo.ArchiveRef(source, archiveRef); err != nil {
+				return err
+			}
+		}
+		if err := repo.RebaseRef(target); err != nil {
+			return err
+		}
+		source, err = r.GetHeadCommit()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := repo.SwitchToRef(target); err != nil {
+		return err
+	}
 	if *submitMerge {
 		submitMessage := fmt.Sprintf("Submitting review %.12s", r.Revision)
 		return repo.MergeRef(source, false, submitMessage, r.Request.Description)
-	} else if *submitRebase {
-		return repo.RebaseRef(source)
 	} else {
 		return repo.MergeRef(source, true)
 	}

--- a/repository/git.go
+++ b/repository/git.go
@@ -322,7 +322,7 @@ func (repo *GitRepo) mergeArchives(archive, remoteArchive string) error {
 //
 // Both the 'ref' and 'archive' arguments are expected to be the fully
 // qualified names of git refs (e.g. 'refs/heads/my-change' or
-// 'refs/archive/devtools').
+// 'refs/devtools/archives/reviews').
 //
 // If the ref pointed to by the 'archive' argument does not exist
 // yet, then it will be created.
@@ -772,8 +772,8 @@ func (repo *GitRepo) PullNotes(remote, notesRefPattern string) error {
 }
 
 func getRemoteArchiveRef(remote, archiveRefPattern string) string {
-	relativeArchiveRef := strings.TrimPrefix(archiveRefPattern, "refs/archives/")
-	return "refs/remoteArchives/" + remote + "/" + relativeArchiveRef
+	relativeArchiveRef := strings.TrimPrefix(archiveRefPattern, "refs/devtools/archives/")
+	return "refs/devtools/remoteArchives/" + remote + "/" + relativeArchiveRef
 }
 
 func (repo *GitRepo) mergeRemoteArchives(remote, archiveRefPattern string) error {

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -352,13 +352,24 @@ func (r mockRepoForTest) SwitchToRef(ref string) error {
 	return nil
 }
 
+// ArchiveRef adds the current commit pointed to by the 'ref' argument
+// under the ref specified in the 'archive' argument.
+//
+// Both the 'ref' and 'archive' arguments are expected to be the fully
+// qualified names of git refs (e.g. 'refs/heads/my-change' or
+// 'refs/archive/devtools').
+//
+// If the ref pointed to by the 'archive' argument does not exist
+// yet, then it will be created.
+func (r mockRepoForTest) ArchiveRef(ref, archive string) error { return nil }
+
 // MergeRef merges the given ref into the current one.
 //
 // The ref argument is the ref to merge, and fastForward indicates that the
 // current ref should only move forward, as opposed to creating a bubble merge.
 func (r mockRepoForTest) MergeRef(ref string, fastForward bool, messages ...string) error { return nil }
 
-// RebaseRef rebases the given ref into the current one.
+// RebaseRef rebases the current ref onto the given one.
 func (r mockRepoForTest) RebaseRef(ref string) error { return nil }
 
 // ListCommits returns the list of commits reachable from the given ref.
@@ -446,3 +457,9 @@ func (r mockRepoForTest) PushNotes(remote, notesRefPattern string) error { retur
 // and then merges them with the corresponding local notes using the
 // "cat_sort_uniq" strategy.
 func (r mockRepoForTest) PullNotes(remote, notesRefPattern string) error { return nil }
+
+// PushArchive pushes the given "archive" ref to a remote repo.
+func (r mockRepoForTest) PushArchive(remote, localArchiveRef string) error { return nil }
+
+// PullArchive pulls the given "archive" ref from a remote repo.
+func (r mockRepoForTest) PullArchive(remote, localArchiveRef string) error { return nil }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -458,10 +458,23 @@ func (r mockRepoForTest) PushNotes(remote, notesRefPattern string) error { retur
 // "cat_sort_uniq" strategy.
 func (r mockRepoForTest) PullNotes(remote, notesRefPattern string) error { return nil }
 
-// PushArchive pushes the given "archive" ref to a remote repo.
-func (r mockRepoForTest) PushArchive(remote, localArchiveRef string) error { return nil }
+// PushNotesAndArchive pushes the given notes and archive refs to a remote repo.
+func (r mockRepoForTest) PushNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error {
+	return nil
+}
 
-// PullArchive pulls the given "archive" ref from a remote repo.
-func (r mockRepoForTest) PullArchive(remote, localArchiveRef, archiveRefPattern string) error {
+// PullNotesAndArchive fetches the contents of the notes and archives refs from
+// a remote repo, and merges them with the corresponding local refs.
+//
+// For notes refs, we assume that every note can be automatically merged using
+// the 'cat_sort_uniq' strategy (the git-appraise schemas fit that requirement),
+// so we automatically merge the remote notes into the local notes.
+//
+// For "archive" refs, they are expected to be used solely for maintaining
+// reachability of commits that are part of the history of any reviews,
+// so we do not maintain any consistency with their tree objects. Instead,
+// we merely ensure that their history graph includes every commit that we
+// intend to keep.
+func (r mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error {
 	return nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -462,4 +462,6 @@ func (r mockRepoForTest) PullNotes(remote, notesRefPattern string) error { retur
 func (r mockRepoForTest) PushArchive(remote, localArchiveRef string) error { return nil }
 
 // PullArchive pulls the given "archive" ref from a remote repo.
-func (r mockRepoForTest) PullArchive(remote, localArchiveRef string) error { return nil }
+func (r mockRepoForTest) PullArchive(remote, localArchiveRef, archiveRefPattern string) error {
+	return nil
+}

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -181,5 +181,5 @@ type Repo interface {
 	// so we do not maintain any consistency with their tree objects. Instead,
 	// we merely ensure that their history graph includes every commit that we
 	// intend to keep.
-	PullArchive(remote, localArchiveRef string) error
+	PullArchive(remote, localArchiveRef, archiveRefPattern string) error
 }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -100,6 +100,17 @@ type Repo interface {
 	// SwitchToRef changes the currently-checked-out ref.
 	SwitchToRef(ref string) error
 
+	// ArchiveRef adds the current commit pointed to by the 'ref' argument
+	// under the ref specified in the 'archive' argument.
+	//
+	// Both the 'ref' and 'archive' arguments are expected to be the fully
+	// qualified names of git refs (e.g. 'refs/heads/my-change' or
+	// 'refs/archive/devtools').
+	//
+	// If the ref pointed to by the 'archive' argument does not exist
+	// yet, then it will be created.
+	ArchiveRef(ref, archive string) error
+
 	// MergeRef merges the given ref into the current one.
 	//
 	// The ref argument is the ref to merge, and fastForward indicates that the
@@ -108,7 +119,7 @@ type Repo interface {
 	// merge commit message (separated by blank lines).
 	MergeRef(ref string, fastForward bool, messages ...string) error
 
-	// RebaseRef rebases the given ref into the current one.
+	// RebaseRef rebases the current ref onto the given one.
 	RebaseRef(ref string) error
 
 	// ListCommits returns the list of commits reachable from the given ref.
@@ -157,4 +168,18 @@ type Repo interface {
 	// and then merges them with the corresponding local notes using the
 	// "cat_sort_uniq" strategy.
 	PullNotes(remote, notesRefPattern string) error
+
+	// PushArchive pushes the given "archive" ref to a remote repo.
+	PushArchive(remote, localArchiveRef string) error
+
+	// PullArchive fetches the contents of the given "archive" ref from a remote
+	// repo, and ensures that every commit reachable from that archive is also
+	// reachable from the local archive.
+	//
+	// These "archive" refs are expected to be used solely for maintaining
+	// reachability of commits that are part of the history of any reviews,
+	// so we do not maintain any consistency with their tree objects. Instead,
+	// we merely ensure that their history graph includes every commit that we
+	// intend to keep.
+	PullArchive(remote, localArchiveRef string) error
 }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -169,17 +169,20 @@ type Repo interface {
 	// "cat_sort_uniq" strategy.
 	PullNotes(remote, notesRefPattern string) error
 
-	// PushArchive pushes the given "archive" ref to a remote repo.
-	PushArchive(remote, localArchiveRef string) error
+	// PushNotesAndArchive pushes the given notes and archive refs to a remote repo.
+	PushNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
 
-	// PullArchive fetches the contents of the given "archive" ref from a remote
-	// repo, and ensures that every commit reachable from that archive is also
-	// reachable from the local archive.
+	// PullNotesAndArchive fetches the contents of the notes and archives refs from
+	// a remote repo, and merges them with the corresponding local refs.
 	//
-	// These "archive" refs are expected to be used solely for maintaining
+	// For notes refs, we assume that every note can be automatically merged using
+	// the 'cat_sort_uniq' strategy (the git-appraise schemas fit that requirement),
+	// so we automatically merge the remote notes into the local notes.
+	//
+	// For "archive" refs, they are expected to be used solely for maintaining
 	// reachability of commits that are part of the history of any reviews,
 	// so we do not maintain any consistency with their tree objects. Instead,
 	// we merely ensure that their history graph includes every commit that we
 	// intend to keep.
-	PullArchive(remote, localArchiveRef, archiveRefPattern string) error
+	PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
 }

--- a/review/request/request.go
+++ b/review/request/request.go
@@ -50,6 +50,9 @@ type Request struct {
 	// This allows someone viewing that submitted review to find the diff against which the
 	// code was reviewed.
 	BaseCommit string `json:"baseCommit,omitempty"`
+	// Alias stores a post-rebase commit ID for the review. This allows the tool
+	// to track the history of a review even if the commit history changes.
+	Alias string `json:"alias,omitempty"`
 }
 
 // New returns a new request.

--- a/schema/request.json
+++ b/schema/request.json
@@ -43,6 +43,11 @@
     "v": {
       "type": "integer",
       "enum": [0]
+    },
+
+    "alias": {
+      "description": "used to specify a post-rebase commit hash for the review",
+      "type": "string"
     }
   },
 


### PR DESCRIPTION
This change improves the support for rebasing reviews in multiple ways:

1. Adding a new `refs/archives/devtools` ref that can be used to make sure that commits which have been rebased do not get garbage collected.
2. Adding a new `alias` field to the request schema that enables tracking review history across rebases.
3. Adding a new `rebase` subcommand that enables us to update the history for a change prior to submitting it.