### PR TITLE
Correctly compute the base commit for abandoned reviews.

### DIFF
--- a/review/request/request.go
+++ b/review/request/request.go
@@ -32,7 +32,7 @@ const FormatVersion = 0
 
 // Request represents an initial request for a code review.
 //
-// Every field except for TargetRef is optional.
+// Every field is optional.
 type Request struct {
 	// Timestamp and Requester are optimizations that allows us to display reviews
 	// without having to run git-blame over the notes object. This is done because

--- a/review/review_test.go
+++ b/review/review_test.go
@@ -653,6 +653,30 @@ func TestGetBaseCommit(t *testing.T) {
 	if pendingReviewBase != repository.TestCommitF {
 		t.Fatal("Unexpected base commit computed for a pending review.")
 	}
+
+	abandonRequest := pendingReview.Request
+	abandonRequest.TargetRef = ""
+	abandonNote, err := abandonRequest.Write()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.AppendNote(request.Ref, repository.TestCommitG, abandonNote); err != nil {
+		t.Fatal(err)
+	}
+	abandonedReview, err := Get(repo, repository.TestCommitG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abandonedReview.IsOpen() {
+		t.Fatal("Failed to update a review to be abandoned")
+	}
+	abandonedReviewBase, err := abandonedReview.GetBaseCommit()
+	if err != nil {
+		t.Fatal("Unable to compute the base commit for an abandoned review: ", err)
+	}
+	if abandonedReviewBase != repository.TestCommitE {
+		t.Fatal("Unexpected base commit computed for an abandoned review.")
+	}
 }
 
 func TestGetRequests(t *testing.T) {


### PR DESCRIPTION
This fixes an issue where the base commit for abandoned reviews
could not be computed (and thus, the diff could not be shown)
because abandoned reviews were being treated as open rather than
closed.

This fixes that issue by making abandoned reviews be treated as
closed.

This also adds a new API method IsOpen to the 'review' package
because I noticed that the underlying logic encapsulated by that
method was being repeated several times.