### PR TITLE
Add a ListCommits method for reviews.

### DIFF
--- a/review/review.go
+++ b/review/review.go
@@ -553,6 +553,19 @@ func (r *Review) GetBaseCommit() (string, error) {
 	return r.Repo.MergeBase(leftHandSide, rightHandSide)
 }
 
+// ListCommits lists the commits included in a review.
+func (r *Review) ListCommits() ([]string, error) {
+	baseCommit, err := r.GetBaseCommit()
+	if err != nil {
+		return nil, err
+	}
+	headCommit, err := r.GetHeadCommit()
+	if err != nil {
+		return nil, err
+	}
+	return r.Repo.ListCommitsBetween(baseCommit, headCommit)
+}
+
 // GetDiff returns the diff for a review.
 func (r *Review) GetDiff(diffArgs ...string) (string, error) {
 	var baseCommit, headCommit string


### PR DESCRIPTION
This is intended for users of git-appraise as a library so that
they do not have to figure out the right logic for listing commits
based on the already provided building blocks (GetBaseCommit
and GetHeadCommit).