### PR TITLE
Validate review hashes when loading a review.

### DIFF
--- a/review/review.go
+++ b/review/review.go
@@ -217,7 +217,7 @@ func (r *Summary) loadComments(commentNotes []repository.Note) []CommentThread {
 func getSummaryFromNotes(repo repository.Repo, revision string, requestNotes, commentNotes []repository.Note) (*Summary, error) {
 	requests := request.ParseAllValid(requestNotes)
 	if requests == nil {
-		return nil, nil
+		return nil, fmt.Errorf("Could not find any review requests for %q", revision)
 	}
 	sort.Stable(requestsByTimestamp(requests))
 	reviewSummary := Summary{
@@ -235,6 +235,9 @@ func getSummaryFromNotes(repo repository.Repo, revision string, requestNotes, co
 //
 // If no review request exists, the returned review summary is nil.
 func GetSummary(repo repository.Repo, revision string) (*Summary, error) {
+	if err := repo.VerifyCommit(revision); err != nil {
+		return nil, fmt.Errorf("Could not find a commit named %q", revision)
+	}
 	requestNotes := repo.GetNotes(request.Ref, revision)
 	commentNotes := repo.GetNotes(comment.Ref, revision)
 	summary, err := getSummaryFromNotes(repo, revision, requestNotes, commentNotes)


### PR DESCRIPTION
This change improves the loading of reviews in two ways:

1. Do not return a nil error from `getSummaryFromNotes` if the returned
   summary is nil, as that breaks assumptions made by callers that one
   of the two return values must be non-nil.
2. Proactively check that the specified hash exists and points to a commit
   object before trying to load a review attached to that commit.

The combination of these two changes fixes #73

The first change prevents the tool from panicing on a bad input, while
the second change makes the error message presented to the user easier
to understand and fix.