### PR TITLE
Implement full source file range support

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -67,13 +67,13 @@ func checkCommentLocation(repo repository.Repo, commit, file string, location co
 	if location.StartLine > uint32(len(lines)) {
 		return fmt.Errorf("Line number %d does not exist in file %q", location.StartLine, file)
 	}
-	if location.StartColumn != 0 && location.StartColumn > uint32(len(lines[location.StartLine])) {
+	if location.StartColumn != 0 && location.StartColumn > uint32(len(lines[location.StartLine-1])) {
 		return fmt.Errorf("Line %d in %q is too short for column %d", location.StartLine, file, location.StartColumn)
 	}
 	if location.EndLine != 0 && location.EndLine > uint32(len(lines)) {
 		return fmt.Errorf("End line number %d does not exist in file %q", location.EndLine, file)
 	}
-	if location.EndColumn != 0 && location.EndColumn > uint32(len(lines[location.EndLine])) {
+	if location.EndColumn != 0 && location.EndColumn > uint32(len(lines[location.EndLine-1])) {
 		return fmt.Errorf("End line %d in %q is too short for column %d", location.EndLine, file, location.EndColumn)
 	}
 	return nil

--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -108,6 +108,10 @@ func showThread(r *review.Review, thread review.CommentThread) error {
 			return err
 		}
 		lines := strings.Split(contents, "\n")
+		err = comment.Location.Check(r.Repo)
+		if err != nil {
+			return err
+		}
 		if comment.Location.Range.StartLine <= uint32(len(lines)) {
 			firstLine := comment.Location.Range.StartLine
 			lastLine := comment.Location.Range.EndLine

--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -19,10 +19,11 @@ package output
 
 import (
 	"fmt"
-	"github.com/google/git-appraise/review"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/git-appraise/review"
 )
 
 const (
@@ -108,13 +109,27 @@ func showThread(r *review.Review, thread review.CommentThread) error {
 		}
 		lines := strings.Split(contents, "\n")
 		if comment.Location.Range.StartLine <= uint32(len(lines)) {
-			var firstLine uint32
-			lastLine := comment.Location.Range.StartLine
-			if lastLine > contextLineCount {
-				firstLine = lastLine - contextLineCount
+			firstLine := comment.Location.Range.StartLine
+			lastLine := comment.Location.Range.EndLine
+
+			if firstLine == 0 {
+				firstLine = 1
 			}
+
+			if lastLine == 0 {
+				lastLine = firstLine
+			}
+
+			if lastLine == firstLine {
+				minLine := int(lastLine) - int(contextLineCount)
+				if minLine <= 0 {
+					minLine = 1
+				}
+				firstLine = uint32(minLine)
+			}
+
 			fmt.Printf(commentLocationTemplate, indent, comment.Location.Path, comment.Location.Commit)
-			fmt.Println(indent + "|" + strings.Join(lines[firstLine:lastLine], "\n"+indent+"|"))
+			fmt.Println(indent + "|" + strings.Join(lines[firstLine-1:lastLine], "\n"+indent+"|"))
 		}
 	}
 	return showSubThread(r, thread, indent)

--- a/review/analyses/analyses.go
+++ b/review/analyses/analyses.go
@@ -19,11 +19,12 @@ package analyses
 
 import (
 	"encoding/json"
-	"github.com/google/git-appraise/repository"
 	"io/ioutil"
 	"net/http"
 	"sort"
 	"strconv"
+
+	"github.com/google/git-appraise/repository"
 )
 
 const (
@@ -53,7 +54,10 @@ type Report struct {
 
 // LocationRange represents the location within a source file that an analysis message covers.
 type LocationRange struct {
-	StartLine int `json:"start_line,omitempty"`
+	StartLine   uint32 `json:"start_line,omitempty"`
+	StartColumn uint32 `json:"start_column,omitempty"`
+	EndLine     uint32 `json:"end_line,omitempty"`
+	EndColumn   uint32 `json:"end_column,omitempty"`
 }
 
 // Location represents the location within a source tree that an analysis message covers.

--- a/review/comment/comment.go
+++ b/review/comment/comment.go
@@ -199,6 +199,11 @@ func parseRangePart(s string) (uint32, uint32, error) {
 		return 0, 0, ErrInvalidRange
 	}
 
+	if line == 0 && col != 0 {
+		// line 0 represents the entire file
+		return 0, 0, ErrInvalidRange
+	}
+
 	return uint32(line), uint32(col), nil
 }
 

--- a/review/comment/comment.go
+++ b/review/comment/comment.go
@@ -37,7 +37,7 @@ const FormatVersion = 0
 
 // ErrInvalidRange inidcates an error during parsing of a user-defined file
 // range
-var ErrInvalidRange = errors.New("invalid file location range. The required form is SL[+SC][:EL[+EC]]")
+var ErrInvalidRange = errors.New("invalid file location range. The required form is StartLine[+StartColumn][:EndLine[+EndColumn]]. The first line in a file is considered to be line 1")
 
 // Range represents the range of text that is under discussion.
 type Range struct {

--- a/schema/comment.json
+++ b/schema/comment.json
@@ -34,6 +34,15 @@
           "properties": {
             "startLine": {
               "type": "integer"
+            },
+            "startColumn": {
+              "type": "integer"
+            },
+            "endLine": {
+              "type": "integer"
+            },
+            "endColumn": {
+              "type": "integer"
             }
           }
         }


### PR DESCRIPTION
The review format from ShipeShape supports fulle specification
of a block of text withint a file. We implement this by allowing
the cli to take a range specified as:

`startLine[+startColumn][:endLine[+endColumn]]`

We need to fully check the semantics of the specified location.
Lines and columns are number from 1 -> max(uint32). The start must
be before the start of the file.