### PR TITLE
Support edited comments.

### DIFF
--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -150,11 +150,7 @@ func showSubThread(r *review.Review, thread review.CommentThread, indent string)
 		}
 	}
 	comment := thread.Comment
-	threadHash, err := comment.Hash()
-	if err != nil {
-		return err
-	}
-
+	threadHash := thread.Hash
 	timestamp := reformatTimestamp(comment.Timestamp)
 	commentSummary := fmt.Sprintf(indent+commentTemplate, threadHash, comment.Author, timestamp, statusString, comment.Description)
 	indent = indent + "  "

--- a/review/comment/comment.go
+++ b/review/comment/comment.go
@@ -103,6 +103,8 @@ type Comment struct {
 	// git-blame will become more and more expensive as the number of code reviews grows.
 	Timestamp string `json:"timestamp,omitempty"`
 	Author    string `json:"author,omitempty"`
+	// If original is provided, then the comment is an updated version of another comment.
+	Original string `json:"original,omitempty"`
 	// If parent is provided, then the comment is a response to another comment.
 	Parent string `json:"parent,omitempty"`
 	// If location is provided, then the comment is specific to that given location.

--- a/schema/comment.json
+++ b/schema/comment.json
@@ -15,6 +15,11 @@
       "type": "string"
     },
 
+    "original": {
+      "description": "the SHA1 hash of another comment on the same revision, and it means this comment is an updated version of that comment",
+      "type": "string"
+    },
+
     "parent": {
       "description": "the SHA1 hash of another comment on the same revision, and it means this comment is a reply to that comment",
       "type": "string"


### PR DESCRIPTION
This change adds read-only support for comment edit actions. These
are represented in the JSON format using a new "original" field that
references the original, unedited comment.

By default, when displaying a comment thread that has been edited,
only the current version of comment is displayed. The full history of
the comment can be viewed by adding the `--json` flag to the
`git appraise show` command, to display the review in JSON format.

This change defines how edits are represented in git-notes and makes
the tool properly display edited comments, but does not add any support
to the tool for creating edits.

This fixes #67