### PR TITLE
Add support for forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This design removes the need for any sort of server-side setup. As a result,
 this tool can work with any git hosting provider, and the only setup required
 is installing the client on your workstation.
 
+Additionally, code reviews can be conducted across multiple hosting providers.
+The list of forks of a repository is also stored in the repository as git
+objects, allowing code reviews to be pulled from every registered fork.
+
 ## Installation
 
 Assuming you have the [Go tools installed](https://golang.org/doc/install), run
@@ -80,7 +84,14 @@ Submitting the current review:
 
     git appraise submit [--merge | --rebase]
 
+Adding a fork:
+
+    git appraise fork add [--owner "<contributor-email>"]+ <name> <url>
+
 A more detailed getting started doc is available [here](docs/tutorial.md).
+
+Instructions for using `git-appraise` with multiple forks can be found
+[here](docs/forks.md).
 
 ## Metadata
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Submitting the current review:
 
 Adding a fork:
 
-    git appraise fork add --owner-emails <contributor-email-addresses> <name> <url>
+    git appraise fork add -o <contributor-email>[,<contributor-email>]* <name> <url>
 
 A more detailed getting started doc is available [here](docs/tutorial.md).
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Submitting the current review:
 
 Adding a fork:
 
-    git appraise fork add [--owner "<contributor-email>"]+ <name> <url>
+    git appraise fork add --owner-emails <contributor-email-addresses> <name> <url>
 
 A more detailed getting started doc is available [here](docs/tutorial.md).
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -43,20 +43,20 @@ func (cmd *Command) Run(repo repository.Repo, args []string) error {
 
 // CommandMap defines all of the available (sub)commands.
 var CommandMap = map[string]*Command{
-	"abandon": abandonCmd,
-	"accept":  acceptCmd,
-	"comment": commentCmd,
-	"fork add": addForkCmd,
-	"fork list": listForksCmd,
+	"abandon":     abandonCmd,
+	"accept":      acceptCmd,
+	"comment":     commentCmd,
+	"fork add":    addForkCmd,
+	"fork list":   listForksCmd,
 	"fork remove": removeForkCmd,
-	"list":    listCmd,
-	"pull":    pullCmd,
-	"push":    pushCmd,
-	"rebase":  rebaseCmd,
-	"reject":  rejectCmd,
-	"request": requestCmd,
-	"show":    showCmd,
-	"submit":  submitCmd,
+	"list":        listCmd,
+	"pull":        pullCmd,
+	"push":        pushCmd,
+	"rebase":      rebaseCmd,
+	"reject":      rejectCmd,
+	"request":     requestCmd,
+	"show":        showCmd,
+	"submit":      submitCmd,
 }
 
 // FindSubcommand parses the subcommand from the list of arguments.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	notesRefPattern   = "refs/notes/devtools/*"
-	forksRefPattern   = "refs/devtools/forks/*"
 	archiveRefPattern = "refs/devtools/archives/*"
 	commentFilename   = "APPRAISE_COMMENT_EDITMSG"
 )

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -23,9 +23,12 @@ import (
 	"github.com/google/git-appraise/repository"
 )
 
-const notesRefPattern = "refs/notes/devtools/*"
-const archiveRefPattern = "refs/devtools/archives/*"
-const commentFilename = "APPRAISE_COMMENT_EDITMSG"
+const (
+	notesRefPattern   = "refs/notes/devtools/*"
+	forksRefPattern   = "refs/devtools/forks/*"
+	archiveRefPattern = "refs/devtools/archives/*"
+	commentFilename   = "APPRAISE_COMMENT_EDITMSG"
+)
 
 // Command represents the definition of a single command.
 type Command struct {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -18,6 +18,8 @@ limitations under the License.
 package commands
 
 import (
+	"fmt"
+
 	"github.com/google/git-appraise/repository"
 )
 
@@ -44,6 +46,9 @@ var CommandMap = map[string]*Command{
 	"abandon": abandonCmd,
 	"accept":  acceptCmd,
 	"comment": commentCmd,
+	"fork add": addForkCmd,
+	"fork list": listForksCmd,
+	"fork remove": removeForkCmd,
 	"list":    listCmd,
 	"pull":    pullCmd,
 	"push":    pushCmd,
@@ -52,4 +57,27 @@ var CommandMap = map[string]*Command{
 	"request": requestCmd,
 	"show":    showCmd,
 	"submit":  submitCmd,
+}
+
+// FindSubcommand parses the subcommand from the list of arguments.
+//
+// The args parameter is the list of command line args after the program name.
+//
+// The return result are the matching command (if found), whether or not the
+// command was found, and the list of remaining command line arguments that
+// followed the subcommand.
+func FindSubcommand(args []string) (*Command, bool, []string) {
+	if len(args) < 1 {
+		subcommand, ok := CommandMap["list"]
+		return subcommand, ok, []string{}
+	}
+	subcommand, ok := CommandMap[args[0]]
+	if ok {
+		return subcommand, ok, args[1:]
+	}
+	if len(args) > 1 {
+		subcommand, ok := CommandMap[fmt.Sprintf("%s %s", args[0], args[1])]
+		return subcommand, ok, args[2:]
+	}
+	return nil, false, []string{}
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindSubcommandBuiltins(t *testing.T) {
+	for name, cmd := range CommandMap {
+		additionalArg := "foo"
+		matchingArgs := append(strings.Split(name, " "), additionalArg)
+		subcommand, ok, remainingArgs := FindSubcommand(matchingArgs)
+		if !ok {
+			t.Errorf("Failed to find the built-in subcommand %q", name)
+		} else if subcommand != cmd {
+			t.Errorf("Return the wrong subcommand for %q", name)
+		} else if len(remainingArgs) != 1 || remainingArgs[0] != additionalArg {
+			t.Errorf("Failed to return the remaining arguments for %q", name)
+		}
+	}
+}
+
+func TestFindSubcommandEmpty(t *testing.T) {
+	subcommand, ok, remaining := FindSubcommand([]string{})
+	if !ok {
+		t.Fatalf("Failed to return a default subcommand")
+	}
+	if subcommand != CommandMap["list"] {
+		t.Fatalf("Failed to return `list` as the default subcommand")
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("Unexpected remaining arguments for an empty command: %q", remaining)
+	}
+}

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/git-appraise/commands/output"
 	"github.com/google/git-appraise/fork"
 	"github.com/google/git-appraise/repository"
 )
@@ -58,7 +59,12 @@ func addFork(repo repository.Repo, args []string) error {
 
 // listForks lists the forks registered in the local git repository.
 func listForks(repo repository.Repo, args []string) error {
-	return errors.New("Not yet implemented.")
+	forks, err := fork.List(repo)
+	if err != nil {
+		return err
+	}
+	output.PrintForks(forks)
+	return nil
 }
 
 // removeFork updates the local git repository to no longer include the specified fork.
@@ -69,7 +75,8 @@ func removeFork(repo repository.Repo, args []string) error {
 	if len(args) > 1 {
 		return errors.New("Only the name of the fork may be specified.")
 	}
-	return errors.New("Not yet implemented.")
+	name := args[0]
+	return fork.Delete(repo, name)
 }
 
 // addForkCmd defines the `fork add` command.

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	addForkFlagSet = flag.NewFlagSet("addFork", flag.ExitOnError)
-	addForkOwners = addForkFlagSet.String("o", "", "Comma-separated list of owner email addresses")
+	addForkOwners  = addForkFlagSet.String("o", "", "Comma-separated list of owner email addresses")
 )
 
 // addFork updates the local git repository to include the specified fork.

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/git-appraise/fork"
 	"github.com/google/git-appraise/repository"
 )
 
@@ -50,7 +51,9 @@ func addFork(repo repository.Repo, args []string) error {
 	if len(owners) == 0 {
 		return errors.New("You must specify at least one owner.")
 	}
-	return errors.New("Not yet implemented.")
+	name := args[0]
+	url := args[1]
+	return fork.Add(repo, fork.New(name, url, owners))
 }
 
 // listForks lists the forks registered in the local git repository.

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/google/git-appraise/repository"
+)
+
+var (
+	addForkFlagSet = flag.NewFlagSet("addFork", flag.ExitOnError)
+	addForkOwnerEmail = addForkFlagSet.String("owner-email", "", "Email address of the owner of the fork")
+)
+
+// addFork updates the local git repository to include the specified fork.
+func addFork(repo repository.Repo, args []string) error {
+	addForkFlagSet.Parse(args)
+	args = addForkFlagSet.Args()
+
+	if len(args) < 2 {
+		return errors.New("The name and URL of the fork must be specified.")
+	}
+	if len(args) > 2 {
+		return errors.New("Only the name and URL of the fork may be specified.")
+	}
+	return errors.New("Not yet implemented.")
+}
+
+// listForks lists the forks registered in the local git repository.
+func listForks(repo repository.Repo, args []string) error {
+	return errors.New("Not yet implemented.")
+}
+
+// removeFork updates the local git repository to no longer include the specified fork.
+func removeFork(repo repository.Repo, args []string) error {
+	if len(args) < 1 {
+		return errors.New("The name of the fork must be specified.")
+	}
+	if len(args) > 1 {
+		return errors.New("Only the name of the fork may be specified.")
+	}
+	return errors.New("Not yet implemented.")
+}
+
+// addForkCmd defines the `fork add` command.
+var addForkCmd = &Command{
+	Usage: func(arg0 string) {
+		fmt.Printf("Usage: %s fork add [<option>...] <name> <url>\n\nOptions:\n", arg0)
+		addForkFlagSet.PrintDefaults()
+	},
+	RunMethod: func(repo repository.Repo, args []string) error {
+		return addFork(repo, args)
+	},
+}
+
+// listForksCmd defines the `fork add` command.
+var listForksCmd = &Command{
+	Usage: func(arg0 string) {
+		fmt.Printf("Usage: %s fork list\n", arg0)
+	},
+	RunMethod: func(repo repository.Repo, args []string) error {
+		return listForks(repo, args)
+	},
+}
+
+// removeForkCmd defines the `fork add` command.
+var removeForkCmd = &Command{
+	Usage: func(arg0 string) {
+		fmt.Printf("Usage: %s fork remove <name>\n", arg0)
+	},
+	RunMethod: func(repo repository.Repo, args []string) error {
+		return removeFork(repo, args)
+	},
+}

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	addForkFlagSet = flag.NewFlagSet("addFork", flag.ExitOnError)
-	addForkOwnerEmails = addForkFlagSet.String("owner-emails", "", "Comma-separated list of owner email addresses")
+	addForkOwners = addForkFlagSet.String("o", "", "Comma-separated list of owner email addresses")
 )
 
 // addFork updates the local git repository to include the specified fork.
@@ -36,8 +36,8 @@ func addFork(repo repository.Repo, args []string) error {
 	args = addForkFlagSet.Args()
 
 	var owners []string
-	if len(*addForkOwnerEmails) > 0 {
-		for _, owner := range strings.Split(*addForkOwnerEmails, ",") {
+	if len(*addForkOwners) > 0 {
+		for _, owner := range strings.Split(*addForkOwners, ",") {
 			owners = append(owners, strings.TrimSpace(owner))
 		}
 	}
@@ -48,7 +48,7 @@ func addFork(repo repository.Repo, args []string) error {
 		return errors.New("Only the name and URL of the fork may be specified.")
 	}
 	if len(owners) == 0 {
-		return errors.New("You must specify at least one owner email address.")
+		return errors.New("You must specify at least one owner.")
 	}
 	return errors.New("Not yet implemented.")
 }

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -20,13 +20,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/google/git-appraise/repository"
 )
 
 var (
 	addForkFlagSet = flag.NewFlagSet("addFork", flag.ExitOnError)
-	addForkOwnerEmail = addForkFlagSet.String("owner-email", "", "Email address of the owner of the fork")
+	addForkOwnerEmails = addForkFlagSet.String("owner-emails", "", "Comma-separated list of owner email addresses")
 )
 
 // addFork updates the local git repository to include the specified fork.
@@ -34,11 +35,20 @@ func addFork(repo repository.Repo, args []string) error {
 	addForkFlagSet.Parse(args)
 	args = addForkFlagSet.Args()
 
+	var owners []string
+	if len(*addForkOwnerEmails) > 0 {
+		for _, owner := range strings.Split(*addForkOwnerEmails, ",") {
+			owners = append(owners, strings.TrimSpace(owner))
+		}
+	}
 	if len(args) < 2 {
 		return errors.New("The name and URL of the fork must be specified.")
 	}
 	if len(args) > 2 {
 		return errors.New("Only the name and URL of the fork may be specified.")
+	}
+	if len(owners) == 0 {
+		return errors.New("You must specify at least one owner email address.")
 	}
 	return errors.New("Not yet implemented.")
 }

--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/git-appraise/fork"
 	"github.com/google/git-appraise/review"
 )
 
@@ -51,6 +52,13 @@ status: %s
 `
 	// Number of lines of context to print for inline comments
 	contextLineCount = 5
+	// Template for printing the summary of the forks.
+	forksSummaryTemplate = `%d forks`
+	// Template for printing the summary of a code review.
+	forkTemplate = `%q
+  owners: %q
+  url: %q
+`
 )
 
 // getStatusString returns a human friendly string encapsulating both the review's
@@ -213,4 +221,12 @@ func PrintDiff(r *review.Review, diffArgs ...string) error {
 	}
 	fmt.Println(diff)
 	return nil
+}
+
+// PrintForks prints the list of forks.
+func PrintForks(forks []*fork.Fork) {
+	fmt.Printf(forksSummaryTemplate, len(forks))
+	for _, f := range forks {
+		fmt.Printf(forkTemplate, f.Name, f.Owners, f.URL)
+	}
 }

--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -57,7 +57,7 @@ status: %s
 	// Template for printing the summary of a code review.
 	forkTemplate = `%q
   owners: %q
-  url: %q
+  urls: %q
 `
 )
 
@@ -227,6 +227,6 @@ func PrintDiff(r *review.Review, diffArgs ...string) error {
 func PrintForks(forks []*fork.Fork) {
 	fmt.Printf(forksSummaryTemplate, len(forks))
 	for _, f := range forks {
-		fmt.Printf(forkTemplate, f.Name, f.Owners, f.URL)
+		fmt.Printf(forkTemplate, f.Name, f.Owners, f.URLS)
 	}
 }

--- a/commands/output/output.go
+++ b/commands/output/output.go
@@ -53,7 +53,8 @@ status: %s
 	// Number of lines of context to print for inline comments
 	contextLineCount = 5
 	// Template for printing the summary of the forks.
-	forksSummaryTemplate = `%d forks`
+	forksSummaryTemplate = `%d forks
+`
 	// Template for printing the summary of a code review.
 	forkTemplate = `%q
   owners: %q

--- a/commands/push.go
+++ b/commands/push.go
@@ -19,6 +19,8 @@ package commands
 import (
 	"errors"
 	"fmt"
+
+	"github.com/google/git-appraise/fork"
 	"github.com/google/git-appraise/repository"
 )
 
@@ -33,7 +35,7 @@ func push(repo repository.Repo, args []string) error {
 		remote = args[0]
 	}
 
-	if err := repo.PushNotesAndArchive(remote, notesRefPattern, archiveRefPattern); err != nil {
+	if err := repo.PushNotesForksAndArchive(remote, notesRefPattern, fork.Ref, archiveRefPattern); err != nil {
 		return err
 	}
 	return nil

--- a/docs/forks.md
+++ b/docs/forks.md
@@ -16,7 +16,7 @@ The owner of the main repository can add a fork with the following command,
 followed by `git appraise push`:
 
 ```shell
-git appraise fork add [--owner "<contributor-email>"]+ <name> <url>
+git appraise fork add --owner-emails <contributor-email-addresses> <name> <url>
 ```
 
 ## Using a fork to request a review

--- a/docs/forks.md
+++ b/docs/forks.md
@@ -16,7 +16,7 @@ The owner of the main repository can add a fork with the following command,
 followed by `git appraise push`:
 
 ```shell
-git appraise fork add --owner-emails <contributor-email-addresses> <name> <url>
+git appraise fork add -o <contributor-email>[,<contributor-email>]* <name> <url>
 ```
 
 ## Using a fork to request a review

--- a/docs/forks.md
+++ b/docs/forks.md
@@ -41,7 +41,7 @@ addresses for the fork.
 
 When running `git appraise pull`, the tool will automatically fetch and merge
 reviews from the forks. This behavior can be controlled using the
-`--[no-]include-forks` flag. Alternatively, it can be configured on a
+`--include-forks` flag. Alternatively, it can be configured on a
 per-remote basis using the `appraise.remote.<remote>.includeForks` setting.
 
 ## Dealing with abusive fork owners

--- a/docs/forks.md
+++ b/docs/forks.md
@@ -64,5 +64,6 @@ git appraise fork remove <name>
 Anyone who runs `git appraise pull --include-forks` can configure a list of
 forks to be excluded from the pull. This is controlled by the config settings
 `appraise.remote.<remote>.excludeFork` and `appraise.excludeFork`. The first
-operates on a per-remote basis and uses either the fork name or URL. The second
-applies to every remote and uses the fork's URL.
+operates on a per-remote basis while the second applies to every remote.
+
+Either option can be configured with either the fork name or URL.

--- a/docs/forks.md
+++ b/docs/forks.md
@@ -1,0 +1,68 @@
+# Working with multiple forks
+
+This file documents how to use `git-appraise` with contributors who do not have
+permission to push to the main repository.
+
+In this model, each contributor sets up their own personal fork of the
+repository. They then push to their fork instead of the main repository.
+
+The list of these forks is stored inside the repository itself, in a special
+ref. The tool uses that list to pull changes and reviews from all the
+registered forks.
+
+## Adding a fork
+
+The owner of the main repository can add a fork with the following command,
+followed by `git appraise push`:
+
+```shell
+git appraise fork add [--owner "<contributor-email>"]+ <name> <url>
+```
+
+## Using a fork to request a review
+
+The owner of a fork can request reviews for any branches they create as long as
+the following rules hold:
+
+1. The name of the branch is prefixed with the name of their fork.
+2. The committer email field of the commit to be reviewed matches
+   one of the owner email addresses of the fork.
+
+To request the review, run the usual `git appraise request ...` command, and
+then use `git appraise push ...` to push it to the fork.
+
+## Using a fork to comment on reviews
+
+The owner of a fork can comment on any code review. The only requirement is
+that the email address they use for git is listed as one of the owner email
+addresses for the fork.
+
+## Pulling code reviews from forks
+
+When running `git appraise pull`, the tool will automatically fetch and merge
+reviews from the forks. This behavior can be controlled using the
+`--[no-]include-forks` flag. Alternatively, it can be configured on a
+per-remote basis using the `appraise.remote.<remote>.includeForks` setting.
+
+## Dealing with abusive fork owners
+
+If the owner of a fork is acting inappropriately, both the owner of the main
+repository and the cloners of that repository have tools to exclude reviews and
+comments from that abusive owner's fork:
+
+### Removing a fork
+
+The owner of the main repository can remove a fork by running the following
+command, followed by `git appraise push`:
+
+```shell
+git appraise fork remove <name>
+```
+
+### Excluding a specific fork
+
+Anyone who runs `git appraise pull --include-forks` can configure a list of
+forks to be excluded from the pull. This is controlled by the config settings
+`appraise.remote.<remote>.excludeFork` and `appraise.excludeFork`. The first
+operates on a per-remote basis and uses either the fork name or URL. The second
+applies to every remote and uses the fork's URL.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -402,3 +402,12 @@ Now that our feature branch has been merged into master, we can delete it:
 git branch -d ${USER}/getting-started
 git push origin --delete ${USER}/getting-started
 ```
+
+# Working with external contributors
+
+The simple workflow above shows how to use `git-appraise` in a single
+repository. However, in practice you do not want to share a single repository
+with every contributor.
+
+Instead, `git-appraise` supports the concept of "forks". Instructions on how to
+use `git-appraise` with multiple forks can be found [here](forks.md)

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -63,7 +63,7 @@ func Delete(repo repository.Repo, name string) error {
 
 // List lists the forks recorded in the repository.
 func List(repo repository.Repo) ([]*Fork, error) {
-	return nil, errors.New("Not yet implemented.")
+	return nil, nil
 }
 
 func Pull(repo repository.Repo, fork *Fork) error {

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -135,11 +135,6 @@ func Add(repo repository.Repo, fork *Fork) error {
 	return repo.SetRef(Ref, commitHash, previousCommitHash)
 }
 
-// Get gets the given fork from the repository.
-func Get(repo repository.Repo, name string) (*Fork, error) {
-	return nil, errors.New("Not yet implemented.")
-}
-
 // Delete deletes the given fork from the repository.
 func Delete(repo repository.Repo, name string) error {
 	return errors.New("Not yet implemented.")
@@ -257,5 +252,5 @@ func List(repo repository.Repo) ([]*Fork, error) {
 }
 
 func Pull(repo repository.Repo, fork *Fork) error {
-	return errors.New("Not yet implemented.")
+	return nil
 }

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fork contains the data structures used to represent repository forks.
+package fork
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/git-appraise/repository"
+)
+
+const Ref = "refs/devtools/forks"
+
+type Fork struct {
+	Name       string   `json:"name,omitempty"`
+	URL        string   `json:"url,omitempty"`
+	Owners     []string `json:"owners,omitempty"`
+	FetchSpecs []string `json:"fetchSpecs,omitempty"`
+}
+
+func New(name, url string, owners []string) *Fork {
+	return &Fork{
+		Name:   name,
+		URL:    url,
+		Owners: owners,
+		FetchSpecs: []string{
+			fmt.Sprintf("refs/heads/%s/*:refs/forks/%s/heads/%s/*", name, name, name),
+			fmt.Sprintf("refs/devtools/*:refs/forks/%s/devtools/%s/*", name, name),
+			fmt.Sprintf("refs/notes/devtools/*:refs/notes/forks/%s/devtools/*", name),
+		},
+	}
+}
+
+// Add adds the given fork to the repository, replacing any existing forks with the same name.
+func Add(repo repository.Repo, fork *Fork) error {
+	return errors.New("Not yet implemented.")
+}
+
+// Get gets the given fork from the repository.
+func Get(repo repository.Repo, name string) (*Fork, error) {
+	return nil, errors.New("Not yet implemented.")
+}
+
+// Delete delets the given fork from the repository.
+func Delete(repo repository.Repo, name string) error {
+	return errors.New("Not yet implemented.")
+}
+
+// List lists the forks recorded in the repository.
+func List(repo repository.Repo) ([]*Fork, error) {
+	return nil, errors.New("Not yet implemented.")
+}
+
+func Pull(repo repository.Repo, fork *Fork) error {
+	return errors.New("Not yet implemented.")
+}

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -293,5 +293,12 @@ func List(repo repository.Repo) ([]*Fork, error) {
 }
 
 func Pull(repo repository.Repo, fork *Fork) error {
+	for _, url := range fork.URLS {
+		var refSpecs []string
+		for _, ref := range fork.Refs {
+			refSpecs = append(refSpecs, fmt.Sprintf("+%s:refs/forks/%s/%s", ref, fork.Name, ref))
+		}
+		repo.Fetch(url, refSpecs)
+	}
 	return nil
 }

--- a/fork/fork.go
+++ b/fork/fork.go
@@ -15,33 +15,51 @@ limitations under the License.
 */
 
 // Package fork contains the data structures used to represent repository forks.
+//
+// Forks are stored in a special ref `refs/devtools/forks`, with a tree that
+// contains one subtree per fork named based on the hash of the fork's name.
+//
+// For example, if there is a fork named "omar", then it will have a SHA1 hash
+// of "728d67f71db99d4768351e8e7807bfdd1807eadb", and be stored under the
+// subtree named "7/2/8d67f71db99d4768351e8e7807bfdd1807eadb".
+//
+// Each fork subtree will contain one file named "NAME" and three directories
+// named "URLS", "OWNERS", and "REFS".
 package fork
 
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/git-appraise/repository"
 )
 
-const Ref = "refs/devtools/forks"
+const (
+	Ref = "refs/devtools/forks"
+
+	nameFile  = "NAME"
+	ownersDir = "OWNERS"
+	refsDir   = "REFS"
+	urlsDir   = "URLS"
+)
 
 type Fork struct {
-	Name       string   `json:"name,omitempty"`
-	URL        string   `json:"url,omitempty"`
-	Owners     []string `json:"owners,omitempty"`
-	FetchSpecs []string `json:"fetchSpecs,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	URLS   []string `json:"urls,omitempty"`
+	Owners []string `json:"owners,omitempty"`
+	Refs   []string `json:"refs,omitempty"`
 }
 
 func New(name, url string, owners []string) *Fork {
 	return &Fork{
 		Name:   name,
-		URL:    url,
+		URLS:   []string{url},
 		Owners: owners,
-		FetchSpecs: []string{
-			fmt.Sprintf("refs/heads/%s/*:refs/forks/%s/heads/%s/*", name, name, name),
-			fmt.Sprintf("refs/devtools/*:refs/forks/%s/devtools/%s/*", name, name),
-			fmt.Sprintf("refs/notes/devtools/*:refs/notes/forks/%s/devtools/*", name),
+		Refs: []string{
+			fmt.Sprintf("refs/heads/%s/*", name),
+			"refs/devtools/*",
+			"refs/notes/devtools/*",
 		},
 	}
 }
@@ -51,19 +69,88 @@ func Add(repo repository.Repo, fork *Fork) error {
 	return errors.New("Not yet implemented.")
 }
 
+func forkNameFromPath(path string) (string, error) {
+	// The path of a fork config item should look like:
+	// <FORK_NAME_AS_SUBPATH>/(urls|owners|refs)/<OBJECT_HASH>,
+	// ... where <FORK_NAME> may be split into multiple path components
+	// to reduce the size of the git tree objects.
+	//
+	// For example, the fork named "omar" will be represented in
+	// a subpath as "o/m/ar", whereas the form named "om" would
+	// simply be "o/m".
+	pathParts := strings.Split(path, "/")
+	if len(pathParts) < 3 {
+		// This is not a valid fork entry
+		return "", fmt.Errorf("Invalid fork configuration item: %q", path)
+	}
+	return strings.Join(pathParts[0:len(pathParts)-2], ""), nil
+}
+
 // Get gets the given fork from the repository.
 func Get(repo repository.Repo, name string) (*Fork, error) {
 	return nil, errors.New("Not yet implemented.")
 }
 
-// Delete delets the given fork from the repository.
+// Delete deletes the given fork from the repository.
 func Delete(repo repository.Repo, name string) error {
 	return errors.New("Not yet implemented.")
 }
 
+func forkHashFromPath(path string) (string, error) {
+	pathParts := strings.Split(path, "/")
+	if len(pathParts) < 4 {
+		return "", fmt.Errorf("Malformed fork config file path: %q", path)
+	}
+	return strings.Join(pathParts[0:3], ""), nil
+}
+
 // List lists the forks recorded in the repository.
 func List(repo repository.Repo) ([]*Fork, error) {
-	return nil, nil
+	hasForks, err := repo.HasRef(Ref)
+	if err != nil {
+		return nil, err
+	}
+	if !hasForks {
+		return nil, nil
+	}
+	forksTree, err := repo.ShowAll(Ref, "/")
+	if err != nil {
+		return nil, err
+	}
+	forkHashesMap := make(map[string]*Fork)
+	for path, contents := range forksTree {
+		forkHash, err := forkHashFromPath(path)
+		if err != nil {
+			continue
+		}
+		fork, ok := forkHashesMap[forkHash]
+		if !ok {
+			fork = &Fork{}
+			forkHashesMap[forkHash] = fork
+		}
+		pathSuffixParts := strings.Split(path, "/")[3:]
+		if len(pathSuffixParts) == 1 && pathSuffixParts[0] == nameFile {
+			fork.Name = contents
+		}
+		if len(pathSuffixParts) != 2 {
+			// An unrecognized fork config entry
+			continue
+		}
+		if pathSuffixParts[0] == ownersDir {
+			fork.Owners = append(fork.Owners, contents)
+		}
+		if pathSuffixParts[0] == refsDir {
+			fork.Refs = append(fork.Refs, contents)
+		}
+		if pathSuffixParts[0] == urlsDir {
+			fork.URLS = append(fork.URLS, contents)
+		}
+	}
+	var forks []*Fork
+	for _, fork := range forkHashesMap {
+		forks = append(forks, fork)
+	}
+	return forks, nil
 }
 
 func Pull(repo repository.Repo, fork *Fork) error {

--- a/fork/fork_test.go
+++ b/fork/fork_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fork
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	localUserName  = "Local Git User For Test"
+	localUserEmail = "test-local-user@example.com"
+	forkUserName   = "Fork Git User For Test"
+	forkUserEmail  = "test-fork-user@example.com"
+)
+
+func createTestRepository() (string, error) {
+	dir, err := ioutil.TempDir("", "test-git-repo")
+	if err != nil {
+		return "", err
+	}
+	initCmd := exec.Command("git", "init")
+	initCmd.Dir = dir
+	err = initCmd.Run()
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+func runGitCommandInRepo(repo string, args []string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to run the git command %v. Stdout: %q, Stderr: %q, Error: %v", args, stdout.String(), stderr.String(), err)
+	}
+	return stdout.String(), nil
+}
+
+type testFork struct {
+	Name  string
+	User  string
+	Email string
+	Dir   string
+}
+
+func newTestFork(remoteRepo, forkName string) (f *testFork, err error) {
+	forkUser := fmt.Sprintf("Test user for %s", forkName)
+	forkEmail := fmt.Sprintf("%s-owner@example.com", forkName)
+	dir, err := createTestRepository()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(dir)
+		}
+	}()
+	remoteAddCmd := []string{"remote", "add", "origin", remoteRepo}
+	pullCmd := []string{"pull", "origin", "master"}
+	if _, err := runGitCommandInRepo(dir, remoteAddCmd); err != nil {
+		return nil, fmt.Errorf("Failed to set up the remote for the test fork repo %q: %v", forkName, err)
+	}
+	if _, err := runGitCommandInRepo(dir, pullCmd); err != nil {
+		return nil, fmt.Errorf("Failed to pull the contents of the remote for the test fork repo %q: %v", forkName, err)
+	}
+	if _, err := runGitCommandInRepo(dir, []string{"config", "--local", "--add", "user.name", forkUser}); err != nil {
+		return nil, fmt.Errorf("Failed to set the git user name for the test fork repo %q: %v", forkName, err)
+	}
+	if _, err := runGitCommandInRepo(dir, []string{"config", "--local", "--add", "user.email", forkEmail}); err != nil {
+		return nil, fmt.Errorf("Failed to set the git user email for the test fork repo %q: %v", forkName, err)
+	}
+	if _, err := runGitCommandInRepo(remoteRepo, []string{"appraise", "fork", "add", "-o", forkEmail, forkName, dir}); err != nil {
+		return nil, fmt.Errorf("Failed to add the fork repo %q as a fork: %v", forkName, err)
+	}
+	return &testFork{
+		Name:  forkName,
+		User:  forkUser,
+		Email: forkEmail,
+		Dir:   dir,
+	}, nil
+}
+
+func (f *testFork) Remove() error {
+	return os.RemoveAll(f.Dir)
+}
+
+func (f *testFork) WriteFile(filename, contents string) error {
+	return ioutil.WriteFile(filepath.Join(f.Dir, filename), []byte(contents), 0644)
+}
+
+func (f *testFork) RunGitCommand(args ...string) (string, error) {
+	return runGitCommandInRepo(f.Dir, args)
+}
+
+func TestPullingFromForks(t *testing.T) {
+	remoteRepo, err := createTestRepository()
+	if err != nil {
+		t.Fatalf("Failed to create the test remote repository: %v", err)
+	}
+	defer os.RemoveAll(remoteRepo)
+	if err := ioutil.WriteFile(filepath.Join(remoteRepo, "README.md"), []byte("# Test Repository"), 0644); err != nil {
+		t.Fatalf("Failed to initialize the contents of the test remote repo: %v", err)
+	}
+	if _, err := runGitCommandInRepo(remoteRepo, []string{"add", "README.md"}); err != nil {
+		t.Fatalf("Failed to add the initial contents of the test remote repo: %v", err)
+	}
+	if _, err := runGitCommandInRepo(remoteRepo, []string{"commit", "-a", "-m", "Initial commit"}); err != nil {
+		t.Fatalf("Failed to commit the initial contents of the test remote repo: %v", err)
+	}
+
+	localRepo, err := newTestFork(remoteRepo, "local")
+	if err != nil {
+		t.Fatalf("Failed to create the test local repository: %v", err)
+	}
+	defer localRepo.Remove()
+
+	for i := 0; i < 10; i++ {
+		forkName := fmt.Sprintf("fork-%d", i)
+		forkRepo, err := newTestFork(remoteRepo, forkName)
+		if err != nil {
+			t.Fatalf("Failed to create the test fork repository %q: %v", forkName, err)
+		}
+		defer forkRepo.Remove()
+		forkBranch := fmt.Sprintf("%s/test-branch", forkName)
+		if _, err := forkRepo.RunGitCommand("checkout", "-b", forkBranch); err != nil {
+			t.Fatalf("Failed to checkout the feature branch of the test fork %q: %v", forkName, err)
+		}
+		if err := forkRepo.WriteFile("Fork.md", fmt.Sprintf("# File written from the fork %q", forkName)); err != nil {
+			t.Fatalf("Failed to initialize the contents of the test fork repo %q feature branch: %v", forkName, err)
+		}
+		if _, err := forkRepo.RunGitCommand("add", "Fork.md"); err != nil {
+			t.Fatalf("Failed to add the contents of the feature branch of the test fork repo: %v", err)
+		}
+		if _, err := forkRepo.RunGitCommand("commit", "-a", "-m", fmt.Sprintf("Add a file from the fork %q", forkName)); err != nil {
+			t.Fatalf("Failed to commit the feature branch of the test fork repo: %v", err)
+		}
+		if _, err := forkRepo.RunGitCommand("appraise", "request"); err != nil {
+			t.Fatalf("Failed to create the review request in the fork repo: %v", err)
+		}
+	}
+
+	if _, err := localRepo.RunGitCommand("appraise", "pull", "origin"); err != nil {
+		t.Fatalf("Failed to pull the review metadata from the remote: %v", err)
+	}
+	if listed, err := localRepo.RunGitCommand("appraise", "list"); err != nil {
+		t.Errorf("Error listing the open reviews: %v", err)
+	} else if len(listed) == 0 {
+		t.Errorf("Failed to list the open reviews")
+	} else if !strings.Contains(listed, "Loaded 10 open reviews") {
+		t.Errorf("Unexpected result from listing the open reviews from forks: %q", listed)
+	}
+}

--- a/fork/fork_test.go
+++ b/fork/fork_test.go
@@ -167,14 +167,16 @@ func TestPullingFromForks(t *testing.T) {
 		}
 	}
 
-	if _, err := localRepo.RunGitCommand("appraise", "pull", "origin"); err != nil {
-		t.Fatalf("Failed to pull the review metadata from the remote: %v", err)
-	}
-	if listed, err := localRepo.RunGitCommand("appraise", "list"); err != nil {
-		t.Errorf("Error listing the open reviews: %v", err)
-	} else if len(listed) == 0 {
-		t.Errorf("Failed to list the open reviews")
-	} else if !strings.Contains(listed, "Loaded 10 open reviews") {
-		t.Errorf("Unexpected result from listing the open reviews from forks: %q", listed)
+	for i := 0; i < 10; i++ {
+		if _, err := localRepo.RunGitCommand("appraise", "pull", "origin"); err != nil {
+			t.Fatalf("Failed to pull the review metadata from the remote: %v", err)
+		}
+		if listed, err := localRepo.RunGitCommand("appraise", "list"); err != nil {
+			t.Errorf("Error listing the open reviews: %v", err)
+		} else if len(listed) == 0 {
+			t.Errorf("Failed to list the open reviews")
+		} else if !strings.Contains(listed, "Loaded 10 open reviews") {
+			t.Errorf("Unexpected result from listing the open reviews from forks: %q", listed)
+		}
 	}
 }

--- a/git-appraise/git-appraise.go
+++ b/git-appraise/git-appraise.go
@@ -58,9 +58,9 @@ func help() {
 		usage()
 		return
 	}
-	subcommand, ok := commands.CommandMap[os.Args[2]]
+	subcommand, ok, _ := commands.FindSubcommand(os.Args[2:])
 	if !ok {
-		fmt.Printf("Unknown command %q\n", os.Args[2])
+		fmt.Printf("Unknown command %q\n", os.Args[2:])
 		usage()
 		return
 	}
@@ -82,22 +82,13 @@ func main() {
 		fmt.Printf("%s must be run from within a git repo.\n", os.Args[0])
 		return
 	}
-	if len(os.Args) < 2 {
-		subcommand, ok := commands.CommandMap["list"]
-		if !ok {
-			fmt.Printf("Unable to list reviews")
-			return
-		}
-		subcommand.Run(repo, []string{})
-		return
-	}
-	subcommand, ok := commands.CommandMap[os.Args[1]]
+	subcommand, ok, remainingArgs := commands.FindSubcommand(os.Args[1:])
 	if !ok {
 		fmt.Printf("Unknown command: %q\n", os.Args[1])
 		usage()
 		return
 	}
-	if err := subcommand.Run(repo, os.Args[2:]); err != nil {
+	if err := subcommand.Run(repo, remainingArgs); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/repository/git.go
+++ b/repository/git.go
@@ -508,6 +508,10 @@ func (repo *GitRepo) ReadTree(ref string) (*Tree, error) {
 		return nil, fmt.Errorf("failure listing the file contents of %q: %v", ref, err)
 	}
 	contents := make(map[string]TreeChild)
+	if len(out) == 0 {
+		// This is possible if the tree is empty
+		return &Tree{contents}, nil
+	}
 	for _, line := range strings.Split(out, "\n") {
 		lineParts := strings.Split(line, "\t")
 		if len(lineParts) != 2 {

--- a/repository/git.go
+++ b/repository/git.go
@@ -527,6 +527,7 @@ func (repo *GitRepo) readTreeWithHash(ref, hash string) (*Tree, error) {
 		// This is possible if the tree is empty
 		return t, nil
 	}
+	contents := t.Contents()
 	for _, line := range strings.Split(out, "\n") {
 		lineParts := strings.Split(line, "\t")
 		if len(lineParts) != 2 {
@@ -550,7 +551,7 @@ func (repo *GitRepo) readTreeWithHash(ref, hash string) (*Tree, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read a tree child object: %v", err)
 		}
-		t.Add(path, child)
+		contents[path] = child
 	}
 	t.savedHash = hash
 	return t, nil

--- a/repository/git.go
+++ b/repository/git.go
@@ -564,6 +564,11 @@ func (repo *GitRepo) CreateCommit(t *Tree, parents []string, message string) (st
 	if err != nil {
 		return "", fmt.Errorf("failure storing a tree: %v", err)
 	}
+	return repo.CreateCommitFromTreeHash(treeHash, parents, message)
+}
+
+// CreateCommitFromTreeHash creates a commit object and returns its hash.
+func (repo *GitRepo) CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error) {
 	args := []string{"commit-tree", treeHash, "-m", message}
 	for _, parent := range parents {
 		args = append(args, "-p", parent)

--- a/repository/git.go
+++ b/repository/git.go
@@ -1015,8 +1015,13 @@ func (repo *GitRepo) mergeRemoteForks(remote, forksRef string) error {
 	workTreeRepo := &GitRepo{
 		Path: dir,
 	}
-	_, err = workTreeRepo.runGitCommand("merge", "--commit", "--no-edit", "-s", "recursive", "-X", "ours", remoteRef)
-	return err
+	if _, err := workTreeRepo.runGitCommand("merge", "--commit", "--allow-unrelated-histories", "--no-edit", "-s", "recursive", "-X", "ours", remoteRef); err != nil {
+		return err
+	}
+	if _, err := workTreeRepo.runGitCommand("update-ref", forksRef, "HEAD"); err != nil {
+		return err
+	}
+	return nil
 }
 
 // PullNotesForksAndArchive fetches the contents of the notes, forks, and archives

--- a/repository/git.go
+++ b/repository/git.go
@@ -34,8 +34,7 @@ const branchRefPrefix = "refs/heads/"
 
 // GitRepo represents an instance of a (local) git repository.
 type GitRepo struct {
-	Path  string
-	Forks map[string]*Fork
+	Path string
 }
 
 // Run the given git command with the given I/O reader/writers, returning an error if it fails.
@@ -710,32 +709,6 @@ func (repo *GitRepo) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
-// AddFork adds the given fork to the repository, replacing any existing forks with the same name.
-func (r *GitRepo) AddFork(forksRef, name string, fork *Fork) error {
-	r.Forks[name] = fork
-	return nil
-}
-
-// GetFork gets the given fork from the repository.
-func (r *GitRepo) GetFork(forksRef, name string) (*Fork, error) {
-	f, ok := r.Forks[name]
-	if !ok {
-		return nil, fmt.Errorf("No fork named %q", name)
-	}
-	return f, nil
-}
-
-// DeleteFork delets the given fork from the repository.
-func (r *GitRepo) DeleteFork(forksRef, name string) error {
-	delete(r.Forks, name)
-	return nil
-}
-
-// ListForks lists the forks recorded in the repository.
-func (r *GitRepo) ListForks(forksRef string) (map[string]*Fork, error) {
-	return r.Forks, nil
-}
-
 // PushNotes pushes git notes to a remote repo.
 func (repo *GitRepo) PushNotes(remote, notesRefPattern string) error {
 	refspec := fmt.Sprintf("%s:%s", notesRefPattern, notesRefPattern)
@@ -855,23 +828,25 @@ func (repo *GitRepo) PullNotesAndArchive(remote, notesRefPattern, archiveRefPatt
 }
 
 // PushNotesForksAndArchive pushes the given notes, forks, and archive refs to a remote repo.
-func (r *GitRepo) PushNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
-	return nil
+func (r *GitRepo) PushNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error {
+	return r.PushNotesAndArchive(remote, notesRefPattern, archiveRefPattern)
 }
 
 // PullNotesForksAndArchive fetches the contents of the notes, forks, and archives
 // refs from  a remote repo, and merges them with the corresponding local refs.
 //
-// For notes and forks refs, we assume that every note can be automatically
-// merged using the 'cat_sort_uniq' strategy (the git-appraise schemas fit
-// that requirement),  so we automatically merge the remote notes into the
-// local notes.
+// For notes refs, we assume that every note can be automatically merged using
+// the 'cat_sort_uniq' strategy (the git-appraise schemas fit that requirement),
+// so we automatically merge the remote notes into the local notes.
+//
+// For the forks ref, we assume that we can merge using the recursive, `ours`,
+// merge strategy.
 //
 // For "archive" refs, they are expected to be used solely for maintaining
 // reachability of commits that are part of the history of any reviews,
 // so we do not maintain any consistency with their tree objects. Instead,
 // we merely ensure that their history graph includes every commit that we
 // intend to keep.
-func (r *GitRepo) PullNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
-	return nil
+func (r *GitRepo) PullNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error {
+	return r.PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern)
 }

--- a/repository/git.go
+++ b/repository/git.go
@@ -1102,17 +1102,17 @@ func (repo *GitRepo) PullNotesForksAndArchive(remote, notesRefPattern, forksRef,
 
 	err := repo.runGitCommandInline("fetch", remote, notesFetchRefSpec, devtoolsFetchRefSpec)
 	if err != nil {
-		return err
+		return fmt.Errorf("failure fetching from the remote %q: %v", remote, err)
 	}
 
 	if err := repo.mergeRemoteNotes(remote, notesRefPattern); err != nil {
-		return err
+		return fmt.Errorf("failure merging notes from the remote %q: %v", remote, err)
 	}
 	if err := repo.mergeRemoteForks(remote, forksRef); err != nil {
-		return err
+		return fmt.Errorf("failure merging forks from the remote %q, %v", remote, err)
 	}
 	if err := repo.mergeRemoteArchives(remote, archiveRefPattern); err != nil {
-		return err
+		return fmt.Errorf("failure merging archives from the remote %q: %v", remote, err)
 	}
 	return nil
 }

--- a/repository/git.go
+++ b/repository/git.go
@@ -845,6 +845,14 @@ func (repo *GitRepo) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
+// Fetch fetches from the given remote using the supplied refspecs.
+func (repo *GitRepo) Fetch(remote string, fetchSpecs []string) error {
+	args := []string{"fetch", remote}
+	args = append(args, fetchSpecs...)
+	_, err := repo.runGitCommand(args...)
+	return err
+}
+
 // PushNotes pushes git notes to a remote repo.
 func (repo *GitRepo) PushNotes(remote, notesRefPattern string) error {
 	refspec := fmt.Sprintf("%s:%s", notesRefPattern, notesRefPattern)

--- a/repository/git.go
+++ b/repository/git.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -860,6 +861,21 @@ func (repo *GitRepo) ListNotedRevisions(notesRef string) []string {
 		}
 	}
 	return revisions
+}
+
+// Remotes returns a list of the remotes.
+func (repo *GitRepo) Remotes() ([]string, error) {
+	remotes, err := repo.runGitCommand("remote")
+	if err != nil {
+		return nil, err
+	}
+	remoteNames := strings.Split(remotes, "\n")
+	var result []string
+	for _, name := range remoteNames {
+		result = append(result, strings.TrimSpace(name))
+	}
+	sort.Strings(result)
+	return result, nil
 }
 
 // Fetch fetches from the given remote using the supplied refspecs.

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -218,8 +218,8 @@ func (r *mockRepoForTest) resolveLocalRef(ref string) (string, error) {
 
 // HasRef checks whether the specified ref exists in the repo.
 func (r *mockRepoForTest) HasRef(ref string) (bool, error) {
-	if err := r.VerifyCommit(ref); err != nil {
-		return false, err
+	if _, ok := r.Refs[ref]; !ok {
+		return false, nil
 	}
 	return true, nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -77,6 +77,7 @@ type mockRepoForTest struct {
 	Refs    map[string]string            `json:"refs,omitempty"`
 	Commits map[string]mockCommit        `json:"commits,omitempty"`
 	Notes   map[string]map[string]string `json:"notes,omitempty"`
+	Forks   map[string]*Fork             `json:"forks,omitempty"`
 }
 
 func (r *mockRepoForTest) createCommit(message string, time string, parents []string) (string, error) {
@@ -176,6 +177,7 @@ func NewMockRepoForTest() Repo {
 				TestCommitD: TestDiscussD,
 			},
 		},
+		Forks: map[string]*Fork{},
 	}
 }
 
@@ -538,6 +540,32 @@ func (r *mockRepoForTest) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
+// AddFork adds the given fork to the repository, replacing any existing forks with the same name.
+func (r *mockRepoForTest) AddFork(forksRef, name string, fork *Fork) error {
+	r.Forks[name] = fork
+	return nil
+}
+
+// GetFork gets the given fork from the repository.
+func (r *mockRepoForTest) GetFork(forksRef, name string) (*Fork, error) {
+	f, ok := r.Forks[name]
+	if !ok {
+		return nil, fmt.Errorf("No fork named %q", name)
+	}
+	return f, nil
+}
+
+// DeleteFork delets the given fork from the repository.
+func (r *mockRepoForTest) DeleteFork(forksRef, name string) error {
+	delete(r.Forks, name)
+	return nil
+}
+
+// ListForks lists the forks recorded in the repository.
+func (r *mockRepoForTest) ListForks(forksRef string) (map[string]*Fork, error) {
+	return r.Forks, nil
+}
+
 // PushNotes pushes git notes to a remote repo.
 func (r *mockRepoForTest) PushNotes(remote, notesRefPattern string) error { return nil }
 
@@ -564,5 +592,27 @@ func (r *mockRepoForTest) PushNotesAndArchive(remote, notesRefPattern, archiveRe
 // we merely ensure that their history graph includes every commit that we
 // intend to keep.
 func (r *mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error {
+	return nil
+}
+
+// PushNotesForksAndArchive pushes the given notes, forks, and archive refs to a remote repo.
+func (r *mockRepoForTest) PushNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
+	return nil
+}
+
+// PullNotesForksAndArchive fetches the contents of the notes, forks, and archives
+// refs from  a remote repo, and merges them with the corresponding local refs.
+//
+// For notes and forks refs, we assume that every note can be automatically
+// merged using the 'cat_sort_uniq' strategy (the git-appraise schemas fit
+// that requirement),  so we automatically merge the remote notes into the
+// local notes.
+//
+// For "archive" refs, they are expected to be used solely for maintaining
+// reachability of commits that are part of the history of any reviews,
+// so we do not maintain any consistency with their tree objects. Instead,
+// we merely ensure that their history graph includes every commit that we
+// intend to keep.
+func (r *mockRepoForTest) PullNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
 	return nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -572,6 +572,11 @@ func (r *mockRepoForTest) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
+// Remotes returns a list of the remotes.
+func (r *mockRepoForTest) Remotes() ([]string, error) {
+	return []string{"origin"}, nil
+}
+
 // Fetch fetches from the given remote using the supplied refspecs.
 func (r *mockRepoForTest) Fetch(remote string, fetchSpecs []string) error { return nil }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -216,6 +216,14 @@ func (r *mockRepoForTest) resolveLocalRef(ref string) (string, error) {
 	return "", fmt.Errorf("The ref %q does not exist", ref)
 }
 
+// HasRef checks whether the specified ref exists in the repo.
+func (r *mockRepoForTest) HasRef(ref string) (bool, error) {
+	if err := r.VerifyCommit(ref); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // VerifyCommit verifies that the supplied hash points to a known commit.
 func (r *mockRepoForTest) VerifyCommit(hash string) error {
 	if _, ok := r.Commits[hash]; !ok {
@@ -373,6 +381,14 @@ func (r *mockRepoForTest) Diff(left, right string, diffArgs ...string) (string, 
 // Show returns the contents of the given file at the given commit.
 func (r *mockRepoForTest) Show(commit, path string) (string, error) {
 	return fmt.Sprintf("%s:%s", commit, path), nil
+}
+
+// ShowAll returns the contents of all the files at the given commit
+// with any of the specified path prefixes.
+//
+// The return value is a map from the fully qualified file path to its contents.
+func (r *mockRepoForTest) ShowAll(commit string, pathPrefixes ...string) (map[string]string, error) {
+	return nil, nil
 }
 
 // SwitchToRef changes the currently-checked-out ref.

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -77,7 +77,6 @@ type mockRepoForTest struct {
 	Refs    map[string]string            `json:"refs,omitempty"`
 	Commits map[string]mockCommit        `json:"commits,omitempty"`
 	Notes   map[string]map[string]string `json:"notes,omitempty"`
-	Forks   map[string]*Fork             `json:"forks,omitempty"`
 }
 
 func (r *mockRepoForTest) createCommit(message string, time string, parents []string) (string, error) {
@@ -177,7 +176,6 @@ func NewMockRepoForTest() Repo {
 				TestCommitD: TestDiscussD,
 			},
 		},
-		Forks: map[string]*Fork{},
 	}
 }
 
@@ -540,32 +538,6 @@ func (r *mockRepoForTest) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
-// AddFork adds the given fork to the repository, replacing any existing forks with the same name.
-func (r *mockRepoForTest) AddFork(forksRef, name string, fork *Fork) error {
-	r.Forks[name] = fork
-	return nil
-}
-
-// GetFork gets the given fork from the repository.
-func (r *mockRepoForTest) GetFork(forksRef, name string) (*Fork, error) {
-	f, ok := r.Forks[name]
-	if !ok {
-		return nil, fmt.Errorf("No fork named %q", name)
-	}
-	return f, nil
-}
-
-// DeleteFork delets the given fork from the repository.
-func (r *mockRepoForTest) DeleteFork(forksRef, name string) error {
-	delete(r.Forks, name)
-	return nil
-}
-
-// ListForks lists the forks recorded in the repository.
-func (r *mockRepoForTest) ListForks(forksRef string) (map[string]*Fork, error) {
-	return r.Forks, nil
-}
-
 // PushNotes pushes git notes to a remote repo.
 func (r *mockRepoForTest) PushNotes(remote, notesRefPattern string) error { return nil }
 
@@ -596,23 +568,25 @@ func (r *mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRe
 }
 
 // PushNotesForksAndArchive pushes the given notes, forks, and archive refs to a remote repo.
-func (r *mockRepoForTest) PushNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
+func (r *mockRepoForTest) PushNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error {
 	return nil
 }
 
 // PullNotesForksAndArchive fetches the contents of the notes, forks, and archives
 // refs from  a remote repo, and merges them with the corresponding local refs.
 //
-// For notes and forks refs, we assume that every note can be automatically
-// merged using the 'cat_sort_uniq' strategy (the git-appraise schemas fit
-// that requirement),  so we automatically merge the remote notes into the
-// local notes.
+// For notes refs, we assume that every note can be automatically merged using
+// the 'cat_sort_uniq' strategy (the git-appraise schemas fit that requirement),
+// so we automatically merge the remote notes into the local notes.
+//
+// For the forks ref, we assume that we can merge using the recursive, `ours`,
+// merge strategy.
 //
 // For "archive" refs, they are expected to be used solely for maintaining
 // reachability of commits that are part of the history of any reviews,
 // so we do not maintain any consistency with their tree objects. Instead,
 // we merely ensure that their history graph includes every commit that we
 // intend to keep.
-func (r *mockRepoForTest) PullNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error {
+func (r *mockRepoForTest) PullNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error {
 	return nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -572,6 +572,9 @@ func (r *mockRepoForTest) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
+// Fetch fetches from the given remote using the supplied refspecs.
+func (r *mockRepoForTest) Fetch(remote string, fetchSpecs []string) error { return nil }
+
 // PushNotes pushes git notes to a remote repo.
 func (r *mockRepoForTest) PushNotes(remote, notesRefPattern string) error { return nil }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -383,14 +383,6 @@ func (r *mockRepoForTest) Show(commit, path string) (string, error) {
 	return fmt.Sprintf("%s:%s", commit, path), nil
 }
 
-// ShowAll returns the contents of all the files at the given commit
-// with any of the specified path prefixes.
-//
-// The return value is a map from the fully qualified file path to its contents.
-func (r *mockRepoForTest) ShowAll(commit string, pathPrefixes ...string) (map[string]string, error) {
-	return nil, nil
-}
-
 // SwitchToRef changes the currently-checked-out ref.
 func (r *mockRepoForTest) SwitchToRef(ref string) error {
 	r.Head = ref
@@ -510,6 +502,32 @@ func (r *mockRepoForTest) ListCommitsBetween(from, to string) ([]string, error) 
 		}
 	}
 	return commits, nil
+}
+
+// StoreBlob writes the given file to the repository and returns its hash.
+func (r *mockRepoForTest) StoreBlob(b *Blob) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// StoreTree writes the given file tree to the repository and returns its hash.
+func (r *mockRepoForTest) StoreTree(t *Tree) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// ReadTree reads the file tree pointed to by the given ref or hash from the repository.
+func (r *mockRepoForTest) ReadTree(ref string) (*Tree, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// CreateCommit creates a commit object and returns its hash.
+func (r *mockRepoForTest) CreateCommit(t *Tree, parents []string, message string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// SetRef sets the commit pointed to by the specified ref to `newCommitHash`,
+// iff the ref currently points `previousCommitHash`.
+func (r *mockRepoForTest) SetRef(ref, newCommitHash, previousCommitHash string) error {
+	return fmt.Errorf("not implemented")
 }
 
 // GetNotes reads the notes from the given ref that annotate the given revision.

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -524,6 +524,11 @@ func (r *mockRepoForTest) CreateCommit(t *Tree, parents []string, message string
 	return "", fmt.Errorf("not implemented")
 }
 
+// CreateCommitFromTreeHash creates a commit object and returns its hash.
+func (r *mockRepoForTest) CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
 // SetRef sets the commit pointed to by the specified ref to `newCommitHash`,
 // iff the ref currently points `previousCommitHash`.
 func (r *mockRepoForTest) SetRef(ref, newCommitHash, previousCommitHash string) error {

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -212,6 +212,9 @@ type Repo interface {
 	// ListNotedRevisions returns the collection of revisions that are annotated by notes in the given ref.
 	ListNotedRevisions(notesRef string) []string
 
+	// Fetch fetches from the given remote using the supplied refspecs.
+	Fetch(remote string, fetchSpecs []string) error
+
 	// PushNotes pushes git notes to a remote repo.
 	PushNotes(remote, notesRefPattern string) error
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -30,12 +30,6 @@ type CommitDetails struct {
 	Summary     string   `json:"summary,omitempty"`
 }
 
-type Fork struct {
-	URL        string   `json:"url,omitempty"`
-	Owners     []string `json:"owners,omitempty"`
-	FetchSpecs []string `json:"fetchSpecs,omitempty"`
-}
-
 // Repo represents a source code repository.
 type Repo interface {
 	// GetPath returns the path to the repo.
@@ -167,18 +161,6 @@ type Repo interface {
 	// ListNotedRevisions returns the collection of revisions that are annotated by notes in the given ref.
 	ListNotedRevisions(notesRef string) []string
 
-	// AddFork adds the given fork to the repository, replacing any existing forks with the same name.
-	AddFork(forksRef, name string, fork *Fork) error
-
-	// GetFork gets the given fork from the repository.
-	GetFork(forksRef, name string) (*Fork, error)
-
-	// DeleteFork delets the given fork from the repository.
-	DeleteFork(forksRef, name string) error
-
-	// ListForks lists the forks recorded in the repository.
-	ListForks(forksRef string) (map[string]*Fork, error)
-
 	// PushNotes pushes git notes to a remote repo.
 	PushNotes(remote, notesRefPattern string) error
 
@@ -205,20 +187,22 @@ type Repo interface {
 	PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
 
 	// PushNotesForksAndArchive pushes the given notes, forks, and archive refs to a remote repo.
-	PushNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error
+	PushNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error
 
 	// PullNotesForksAndArchive fetches the contents of the notes, forks, and archives
 	// refs from  a remote repo, and merges them with the corresponding local refs.
 	//
-	// For notes and forks refs, we assume that every note can be automatically
-	// merged using the 'cat_sort_uniq' strategy (the git-appraise schemas fit
-	// that requirement),  so we automatically merge the remote notes into the
-	// local notes.
+	// For notes refs, we assume that every note can be automatically merged using
+	// the 'cat_sort_uniq' strategy (the git-appraise schemas fit that requirement),
+	// so we automatically merge the remote notes into the local notes.
+	//
+	// For the forks ref, we assume that we can merge using the recursive, `ours`,
+	// merge strategy.
 	//
 	// For "archive" refs, they are expected to be used solely for maintaining
 	// reachability of commits that are part of the history of any reviews,
 	// so we do not maintain any consistency with their tree objects. Instead,
 	// we merely ensure that their history graph includes every commit that we
 	// intend to keep.
-	PullNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error
+	PullNotesForksAndArchive(remote, notesRefPattern, forksRef, archiveRefPattern string) error
 }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -30,6 +30,12 @@ type CommitDetails struct {
 	Summary     string   `json:"summary,omitempty"`
 }
 
+type Fork struct {
+	URL        string   `json:"url,omitempty"`
+	Owners     []string `json:"owners,omitempty"`
+	FetchSpecs []string `json:"fetchSpecs,omitempty"`
+}
+
 // Repo represents a source code repository.
 type Repo interface {
 	// GetPath returns the path to the repo.
@@ -161,6 +167,18 @@ type Repo interface {
 	// ListNotedRevisions returns the collection of revisions that are annotated by notes in the given ref.
 	ListNotedRevisions(notesRef string) []string
 
+	// AddFork adds the given fork to the repository, replacing any existing forks with the same name.
+	AddFork(forksRef, name string, fork *Fork) error
+
+	// GetFork gets the given fork from the repository.
+	GetFork(forksRef, name string) (*Fork, error)
+
+	// DeleteFork delets the given fork from the repository.
+	DeleteFork(forksRef, name string) error
+
+	// ListForks lists the forks recorded in the repository.
+	ListForks(forksRef string) (map[string]*Fork, error)
+
 	// PushNotes pushes git notes to a remote repo.
 	PushNotes(remote, notesRefPattern string) error
 
@@ -185,4 +203,22 @@ type Repo interface {
 	// we merely ensure that their history graph includes every commit that we
 	// intend to keep.
 	PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
+
+	// PushNotesForksAndArchive pushes the given notes, forks, and archive refs to a remote repo.
+	PushNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error
+
+	// PullNotesForksAndArchive fetches the contents of the notes, forks, and archives
+	// refs from  a remote repo, and merges them with the corresponding local refs.
+	//
+	// For notes and forks refs, we assume that every note can be automatically
+	// merged using the 'cat_sort_uniq' strategy (the git-appraise schemas fit
+	// that requirement),  so we automatically merge the remote notes into the
+	// local notes.
+	//
+	// For "archive" refs, they are expected to be used solely for maintaining
+	// reachability of commits that are part of the history of any reviews,
+	// so we do not maintain any consistency with their tree objects. Instead,
+	// we merely ensure that their history graph includes every commit that we
+	// intend to keep.
+	PullNotesForksAndArchive(remote, notesRefPattern, forksRefPattern, archiveRefPattern string) error
 }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -71,23 +71,6 @@ func (t *Tree) Store(repo Repo) (string, error) {
 	return repo.StoreTree(t)
 }
 
-func (t *Tree) Add(name string, child TreeChild) {
-	t.contents[name] = child
-	t.savedHash = ""
-}
-
-func (t *Tree) Get(name string) (TreeChild, bool) {
-	child, ok := t.contents[name]
-	// Since the returned child is mutable, we have to assume the hash could change.
-	t.savedHash = ""
-	return child, ok
-}
-
-func (t *Tree) Delete(name string) {
-	delete(t.contents, name)
-	t.savedHash = ""
-}
-
 func (t *Tree) Contents() map[string]TreeChild {
 	// Since the returned contents are mutable, we have to assume the hash could change.
 	t.savedHash = ""

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -50,6 +50,9 @@ type Repo interface {
 	// HasUncommittedChanges returns true if there are local, uncommitted changes.
 	HasUncommittedChanges() (bool, error)
 
+	// HasRef checks whether the specified ref exists in the repo.
+	HasRef(ref string) (bool, error)
+
 	// VerifyCommit verifies that the supplied hash points to a known commit.
 	VerifyCommit(hash string) error
 
@@ -96,6 +99,12 @@ type Repo interface {
 
 	// Show returns the contents of the given file at the given commit.
 	Show(commit, path string) (string, error)
+
+	// ShowAll returns the contents of all the files at the given commit
+	// with any of the specified path prefixes.
+	//
+	// The return value is a map from the fully qualified file path to its contents.
+	ShowAll(commit string, pathPrefixes ...string) (map[string]string, error)
 
 	// SwitchToRef changes the currently-checked-out ref.
 	SwitchToRef(ref string) error

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -227,6 +227,9 @@ type Repo interface {
 	// ListNotedRevisions returns the collection of revisions that are annotated by notes in the given ref.
 	ListNotedRevisions(notesRef string) []string
 
+	// Remotes returns a list of the remotes.
+	Remotes() ([]string, error)
+
 	// Fetch fetches from the given remote using the supplied refspecs.
 	Fetch(remote string, fetchSpecs []string) error
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -17,8 +17,18 @@ limitations under the License.
 // Package repository contains helper methods for working with a Git repo.
 package repository
 
+import (
+	"crypto/sha1"
+	"fmt"
+)
+
 // Note represents the contents of a git-note
 type Note []byte
+
+// Hash returns a hash of the given note
+func (n Note) Hash() string {
+	return fmt.Sprintf("%x", sha1.Sum([]byte(n)))
+}
 
 // CommitDetails represents the contents of a commit.
 type CommitDetails struct {
@@ -206,6 +216,9 @@ type Repo interface {
 
 	// CreateCommit creates a commit object and returns its hash.
 	CreateCommit(t *Tree, parents []string, message string) (string, error)
+
+	// CreateCommitFromTreeHash creates a commit object and returns its hash.
+	CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error)
 
 	// SetRef sets the commit pointed to by the specified ref to `newCommitHash`,
 	// iff the ref currently points `previousCommitHash`.

--- a/review/review.go
+++ b/review/review.go
@@ -21,12 +21,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/google/git-appraise/repository"
 	"github.com/google/git-appraise/review/analyses"
 	"github.com/google/git-appraise/review/ci"
 	"github.com/google/git-appraise/review/comment"
 	"github.com/google/git-appraise/review/request"
-	"sort"
 )
 
 const archiveRef = "refs/devtools/archives/reviews"
@@ -546,6 +548,44 @@ func (r *Summary) getStartingCommit() string {
 	return r.Revision
 }
 
+// LocalReviewRef finds the local ref that most closely matches the review ref.
+//
+// For refs outside of refs/heads/ (i.e. non-branches), the local ref has to
+// match the review ref exactly.
+//
+// For branches, the following are checked in order:
+// 1. An exact match in the local branches.
+// 2. A matching branch in the `origin` remote.
+// 3. A matching branch in a matching fork (e.g. if the branch starts with "somefork/", then look under "refs/forks/somefork/refs/heads/somefork/...").
+func (r *Review) LocalReviewRef() (string, error) {
+	if !strings.HasPrefix(r.Request.ReviewRef, "refs/heads/") {
+		return r.Request.ReviewRef, nil
+	}
+	if hasRef, err := r.Repo.HasRef(r.Request.ReviewRef); err != nil {
+		return "", err
+	} else if hasRef {
+		return r.Request.ReviewRef, nil
+	}
+	branchName := strings.TrimPrefix(r.Request.ReviewRef, "refs/heads/")
+	originBranch := "refs/remotes/origin/" + branchName
+	if hasRef, err := r.Repo.HasRef(originBranch); err != nil {
+		return "", err
+	} else if hasRef {
+		return originBranch, nil
+	}
+	if strings.Index(branchName, "/") <= 0 {
+		return r.Request.ReviewRef, nil
+	}
+	forkName := branchName[0:strings.Index(branchName, "/")]
+	forkBranch := "refs/forks/" + forkName + "/refs/heads/" + branchName
+	if hasRef, err := r.Repo.HasRef(forkBranch); err != nil {
+		return "", err
+	} else if hasRef {
+		return forkBranch, nil
+	}
+	return r.Request.ReviewRef, nil
+}
+
 // GetHeadCommit returns the latest commit in a review.
 func (r *Review) GetHeadCommit() (string, error) {
 	currentCommit := r.getStartingCommit()
@@ -562,12 +602,16 @@ func (r *Review) GetHeadCommit() (string, error) {
 	// It is possible that the review ref is no longer an ancestor of the starting
 	// commit (e.g. if a rebase left us in a detached head), in which case we have to
 	// find the head commit without using it.
-	useReviewRef, err := r.Repo.IsAncestor(currentCommit, r.Request.ReviewRef)
+	reviewRef, err := r.LocalReviewRef()
+	if err != nil {
+		return "", err
+	}
+	useReviewRef, err := r.Repo.IsAncestor(currentCommit, reviewRef)
 	if err != nil {
 		return "", err
 	}
 	if useReviewRef {
-		return r.Repo.ResolveRefCommit(r.Request.ReviewRef)
+		return r.Repo.ResolveRefCommit(reviewRef)
 	}
 
 	return r.findLastCommit(currentCommit, currentCommit, r.Comments), nil


### PR DESCRIPTION
This change adds the concept of "forks" to git-appraise.

The underlying idea is that each contributor can have their own personal repository to which they push, and that the overarching repository can be viewed as a compilation of those separate repositories.

In essence, we are adding symbolic links to other repositories inside the repo itself, and then resolving those links on the client side.

Each entry in this collection of symbolic links is what we call a "fork", and the collection includes all of the information that a client needs to know how to fetch from each fork and which notes should be merged from each fork.

By doing this, we unlock the ability to perform reviews across multiple remote repositories, and even entirely separate hosting providers.

For example, one contributor could have a repository that they push to on GitHub, another can have one on GitLab, and a third could have one stored in GitTorrent, and all three could push to their respective repositories while reviewing code from each other.

This fixes #71 