### PR TITLE
Adds GPG signing and verification

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -61,10 +61,6 @@ func pull(repo repository.Repo, args []string) error {
 	if err != nil {
 		return err
 	}
-	key, err := repo.GetUserSigningKey()
-	if err != nil {
-		return err
-	}
 	for _, revision := range revisions {
 		rvw, err := review.GetSummaryViaRefs(repo,
 			"refs/notes/"+remote+"/devtools/reviews",
@@ -72,7 +68,7 @@ func pull(repo repository.Repo, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = rvw.Verify(key)
+		err = rvw.Verify()
 		if err != nil {
 			return err
 		}

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -18,30 +18,74 @@ package commands
 
 import (
 	"errors"
+	"flag"
 	"fmt"
+
 	"github.com/google/git-appraise/repository"
+	"github.com/google/git-appraise/review"
 )
 
-// pull updates the local git-notes used for reviews with those from a remote repo.
+var (
+	pullFlagSet = flag.NewFlagSet("pull", flag.ExitOnError)
+	pullVerify  = pullFlagSet.Bool("verify-signatures", false,
+		"verify the signatures of pulled reviews")
+)
+
+// pull updates the local git-notes used for reviews with those from a remote
+// repo.
 func pull(repo repository.Repo, args []string) error {
-	if len(args) > 1 {
-		return errors.New("Only pulling from one remote at a time is supported.")
+	pullFlagSet.Parse(args)
+	pullArgs := pullFlagSet.Args()
+
+	if len(pullArgs) > 1 {
+		return errors.New(
+			"Only pulling from one remote at a time is supported.")
 	}
 
 	remote := "origin"
-	if len(args) == 1 {
-		remote = args[0]
+	if len(pullArgs) == 1 {
+		remote = pullArgs[0]
+	}
+	// This is the easy case. We're not checking signatures so just go the
+	// normal route.
+	if !*pullVerify {
+		return repo.PullNotesAndArchive(remote, notesRefPattern,
+			archiveRefPattern)
 	}
 
-	if err := repo.PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern); err != nil {
+	// Otherwise, we collect the fetched reviewed revisions (their hashes), get
+	// their reviews, and then one by one, verify them. If we make it through
+	// the set, _then_ we merge the remote reference into the local branch.
+	revisions, err := repo.FetchAndReturnNewReviewHashes(remote,
+		notesRefPattern, archiveRefPattern)
+	if err != nil {
 		return err
 	}
-	return nil
+	key, err := repo.GetUserSigningKey()
+	if err != nil {
+		return err
+	}
+	for _, revision := range revisions {
+		rvw, err := review.GetSummaryViaRefs(repo,
+			"refs/notes/"+remote+"/devtools/reviews",
+			"refs/notes/"+remote+"/devtools/discuss", revision)
+		if err != nil {
+			return err
+		}
+		err = rvw.Verify(key)
+		if err != nil {
+			return err
+		}
+		fmt.Println("verified review:", revision)
+	}
+
+	return repo.MergeNotesAndArchive(remote, notesRefPattern,
+		archiveRefPattern)
 }
 
 var pullCmd = &Command{
 	Usage: func(arg0 string) {
-		fmt.Printf("Usage: %s pull [<remote>]\n", arg0)
+		fmt.Printf("Usage: %s pull [<option>] [<remote>]\n", arg0)
 	},
 	RunMethod: func(repo repository.Repo, args []string) error {
 		return pull(repo, args)

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -79,8 +79,11 @@ func pull(repo repository.Repo, args []string) error {
 		fmt.Println("verified review:", revision)
 	}
 
-	return repo.MergeNotesAndArchive(remote, notesRefPattern,
-		archiveRefPattern)
+	err = repo.MergeNotes(remote, notesRefPattern)
+	if err != nil {
+		return err
+	}
+	return repo.MergeArchives(remote, archiveRefPattern)
 }
 
 var pullCmd = &Command{

--- a/commands/rebase.go
+++ b/commands/rebase.go
@@ -82,7 +82,10 @@ func rebaseReview(repo repository.Repo, args []string) error {
 	if err != nil {
 		return err
 	}
-	return r.Rebase(*rebaseArchive, *rebaseSign)
+	if *rebaseSign {
+		return r.RebaseAndSign(*rebaseArchive)
+	}
+	return r.Rebase(*rebaseArchive)
 }
 
 // rebaseCmd defines the "rebase" subcommand.

--- a/commands/rebase.go
+++ b/commands/rebase.go
@@ -29,6 +29,8 @@ var rebaseFlagSet = flag.NewFlagSet("rebase", flag.ExitOnError)
 
 var (
 	rebaseArchive = rebaseFlagSet.Bool("archive", true, "Prevent the original commit from being garbage collected.")
+	rebaseSign    = rebaseFlagSet.Bool("S", false,
+		"Sign the contents of the request after the rebase")
 )
 
 // Validate that the user's request to rebase a review makes sense.
@@ -80,7 +82,7 @@ func rebaseReview(repo repository.Repo, args []string) error {
 	if err != nil {
 		return err
 	}
-	return r.Rebase(*rebaseArchive)
+	return r.Rebase(*rebaseArchive, *rebaseSign)
 }
 
 // rebaseCmd defines the "rebase" subcommand.

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -32,6 +32,9 @@ var (
 	submitFastForward = submitFlagSet.Bool("fast-forward", false, "Create a merge using the default fast-forward mode.")
 	submitTBR         = submitFlagSet.Bool("tbr", false, "(To be reviewed) Force the submission of a review that has not been accepted.")
 	submitArchive     = submitFlagSet.Bool("archive", true, "Prevent the original commit from being garbage collected; only affects rebased submits.")
+
+	submitSign = submitFlagSet.Bool("S", false,
+		"Sign the contents of the submission")
 )
 
 // Submit the current code review request.
@@ -105,7 +108,7 @@ func submitReview(repo repository.Repo, args []string) error {
 	}
 
 	if *submitRebase {
-		if err := r.Rebase(*submitArchive); err != nil {
+		if err := r.Rebase(*submitArchive, *submitSign); err != nil {
 			return err
 		}
 		source, err = r.GetHeadCommit()
@@ -119,9 +122,10 @@ func submitReview(repo repository.Repo, args []string) error {
 	}
 	if *submitMerge {
 		submitMessage := fmt.Sprintf("Submitting review %.12s", r.Revision)
-		return repo.MergeRef(source, false, submitMessage, r.Request.Description)
+		return repo.MergeRef(source, false, *submitSign, submitMessage,
+			r.Request.Description)
 	} else {
-		return repo.MergeRef(source, true)
+		return repo.MergeRef(source, true, *submitSign)
 	}
 }
 

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -108,9 +108,16 @@ func submitReview(repo repository.Repo, args []string) error {
 	}
 
 	if *submitRebase {
-		if err := r.Rebase(*submitArchive, *submitSign); err != nil {
+		var err error
+		if *submitSign {
+			err = r.RebaseAndSign(*submitArchive)
+		} else {
+			err = r.Rebase(*submitArchive)
+		}
+		if err != nil {
 			return err
 		}
+
 		source, err = r.GetHeadCommit()
 		if err != nil {
 			return err
@@ -122,10 +129,19 @@ func submitReview(repo repository.Repo, args []string) error {
 	}
 	if *submitMerge {
 		submitMessage := fmt.Sprintf("Submitting review %.12s", r.Revision)
-		return repo.MergeRef(source, false, *submitSign, submitMessage,
-			r.Request.Description)
+		if *submitSign {
+			return repo.MergeAndSignRef(source, false, submitMessage,
+				r.Request.Description)
+		} else {
+			return repo.MergeRef(source, false, submitMessage,
+				r.Request.Description)
+		}
 	} else {
-		return repo.MergeRef(source, true, *submitSign)
+		if *submitSign {
+			return repo.MergeAndSignRef(source, true)
+		} else {
+			return repo.MergeRef(source, true)
+		}
 	}
 }
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -369,15 +369,36 @@ func (repo *GitRepo) ArchiveRef(ref, archive string) error {
 // current ref should only move forward, as opposed to creating a bubble merge.
 // The messages argument(s) provide text that should be included in the default
 // merge commit message (separated by blank lines).
-func (repo *GitRepo) MergeRef(ref string, fastForward, sign bool, messages ...string) error {
+func (repo *GitRepo) MergeRef(ref string, fastForward bool, messages ...string) error {
 	args := []string{"merge"}
 	if fastForward {
 		args = append(args, "--ff", "--ff-only")
 	} else {
 		args = append(args, "--no-ff")
 	}
-	if sign {
-		args = append(args, "-S")
+	if len(messages) > 0 {
+		commitMessage := strings.Join(messages, "\n\n")
+		args = append(args, "-e", "-m", commitMessage)
+	}
+	args = append(args, ref)
+	return repo.runGitCommandInline(args...)
+}
+
+// MergeAndSignRef merges the given ref into the current one and signs the
+// merge.
+//
+// The ref argument is the ref to merge, and fastForward indicates that the
+// current ref should only move forward, as opposed to creating a bubble merge.
+// The messages argument(s) provide text that should be included in the default
+// merge commit message (separated by blank lines).
+func (repo *GitRepo) MergeAndSignRef(ref string, fastForward bool,
+	messages ...string) error {
+
+	args := []string{"merge"}
+	if fastForward {
+		args = append(args, "--ff", "--ff-only", "-S")
+	} else {
+		args = append(args, "--no-ff", "-S")
 	}
 	if len(messages) > 0 {
 		commitMessage := strings.Join(messages, "\n\n")
@@ -388,11 +409,14 @@ func (repo *GitRepo) MergeRef(ref string, fastForward, sign bool, messages ...st
 }
 
 // RebaseRef rebases the current ref onto the given one.
-func (repo *GitRepo) RebaseRef(ref string, sign bool) error {
-	if sign {
-		return repo.runGitCommandInline("rebase", "-S", "-i", ref)
-	}
+func (repo *GitRepo) RebaseRef(ref string) error {
 	return repo.runGitCommandInline("rebase", "-i", ref)
+}
+
+// RebaseAndSignRef rebases the current ref onto the given one and signs the
+// result.
+func (repo *GitRepo) RebaseAndSignRef(ref string) error {
+	return repo.runGitCommandInline("rebase", "-S", "-i", ref)
 }
 
 // ListCommits returns the list of commits reachable from the given ref.
@@ -857,48 +881,107 @@ func (repo *GitRepo) PullNotesAndArchive(remote, notesRefPattern, archiveRefPatt
 func (repo *GitRepo) FetchAndReturnNewReviewHashes(remote, notesRefPattern,
 	archiveRefPattern string) ([]string, error) {
 
-	beforeHash, err := repo.GetCommitHash(
+	// Record the current state of the reviews and comments refs.
+	var (
+		getAllRevs, getAllComs    bool
+		reviewsList, commentsList []string
+	)
+	reviewBeforeHash, err := repo.GetCommitHash(
 		"notes/" + remote + "/devtools/reviews")
-	if err != nil {
-		// We don't have a reference for our remote yet. This is the first
-		// fetch of notes. We need to return _all_ hashes, which is to say,
-		// all the files present at where the reference
-		// `notes/<remote>/reviews' points.
-		err = repo.fetchNotes(remote, notesRefPattern, archiveRefPattern)
-		if err != nil {
-			return nil, err
-		}
-		hash, err := repo.GetCommitHash(
-			"notes/" + remote + "/devtools/reviews")
-		if err != nil {
-			return nil, err
-		}
-		rvws, err := repo.runGitCommand("ls-tree", "-r", "--name-only", hash)
-		if err != nil {
-			return nil, err
-		}
-		return strings.Split(rvws, "\n"), nil
-	}
+	getAllRevs = err != nil
 
+	commentBeforeHash, err := repo.GetCommitHash(
+		"notes/" + remote + "/devtools/discuss")
+	getAllComs = err != nil
+
+	// Update them from the remote.
 	err = repo.fetchNotes(remote, notesRefPattern, archiveRefPattern)
 	if err != nil {
 		return nil, err
 	}
-	afterHash, err := repo.GetCommitHash(
-		"notes/" + remote + "/devtools/reviews")
-	if err != nil {
-		return nil, err
+
+	// Now, if either of these are new refs, we just use the whole tree at that
+	// new ref. Otherwise we see which reviews or comments changed and collect
+	// them into a list.
+	if getAllRevs {
+		hash, err := repo.GetCommitHash(
+			"notes/" + remote + "/devtools/reviews")
+		// It is possible that even after we've pulled that this ref still
+		// isn't present (because there are no reviews yet).
+		if err == nil {
+			rvws, err := repo.runGitCommand("ls-tree", "-r", "--name-only",
+				hash)
+			if err != nil {
+				return nil, err
+			}
+			reviewsList = strings.Split(strings.Replace(rvws, "/", "", -1),
+				"\n")
+		}
+	} else {
+		reviewAfterHash, err := repo.GetCommitHash(
+			"notes/" + remote + "/devtools/reviews")
+		if err != nil {
+			return nil, err
+		}
+
+		// Only run through this if the fetch fetched new revisions.
+		// Otherwise leave reviewsList as its default value, an empty slice
+		// of strings.
+		if reviewBeforeHash != reviewAfterHash {
+			newReviewsRaw, err := repo.runGitCommand("diff", "--name-only",
+				reviewBeforeHash, reviewAfterHash)
+			if err != nil {
+				return nil, err
+			}
+			reviewsList = strings.Split(strings.Replace(newReviewsRaw,
+				"/", "", -1), "\n")
+		}
 	}
 
-	// Nothing new here.
-	if beforeHash == afterHash {
-		return []string{}, nil
+	if getAllComs {
+		hash, err := repo.GetCommitHash(
+			"notes/" + remote + "/devtools/discuss")
+		// It is possible that even after we've pulled that this ref still
+		// isn't present (because there are no comments yet).
+		if err == nil {
+			rvws, err := repo.runGitCommand("ls-tree", "-r", "--name-only",
+				hash)
+			if err != nil {
+				return nil, err
+			}
+			commentsList = strings.Split(strings.Replace(rvws, "/", "", -1),
+				"\n")
+		}
+	} else {
+		commentAfterHash, err := repo.GetCommitHash(
+			"notes/" + remote + "/devtools/discuss")
+		if err != nil {
+			return nil, err
+		}
+
+		// Only run through this if the fetch fetched new revisions.
+		// Otherwise leave commentsList as its default value, an empty slice
+		// of strings.
+		if commentBeforeHash != commentAfterHash {
+			newCommentsRaw, err := repo.runGitCommand("diff", "--name-only",
+				commentBeforeHash, commentAfterHash)
+			if err != nil {
+				return nil, err
+			}
+			commentsList = strings.Split(strings.Replace(newCommentsRaw,
+				"/", "", -1), "\n")
+		}
 	}
 
-	newReviews, err := repo.runGitCommand("diff", "--name-only", beforeHash,
-		afterHash)
-	if err != nil {
-		return nil, err
+	// Now that we have our two lists, we need to merge them.
+	updatedReviewSet := make(map[string]struct{})
+	for _, hash := range append(reviewsList, commentsList...) {
+		updatedReviewSet[hash] = struct{}{}
 	}
-	return strings.Split(newReviews, "\n"), nil
+
+	updatedReviews := make([]string, 0, len(updatedReviewSet))
+	for key, _ := range updatedReviewSet {
+		updatedReviews = append(updatedReviews, key)
+	}
+	return updatedReviews, nil
 }

--- a/repository/git.go
+++ b/repository/git.go
@@ -102,6 +102,12 @@ func (repo *GitRepo) GetUserEmail() (string, error) {
 	return repo.runGitCommand("config", "user.email")
 }
 
+// GetUserSigningKey returns the key id the user has configured for
+// sigining git artifacts.
+func (repo *GitRepo) GetUserSigningKey() (string, error) {
+	return repo.runGitCommand("config", "user.signingKey")
+}
+
 // GetCoreEditor returns the name of the editor that the user has used to configure git.
 func (repo *GitRepo) GetCoreEditor() (string, error) {
 	return repo.runGitCommand("var", "GIT_EDITOR")

--- a/repository/git.go
+++ b/repository/git.go
@@ -369,12 +369,15 @@ func (repo *GitRepo) ArchiveRef(ref, archive string) error {
 // current ref should only move forward, as opposed to creating a bubble merge.
 // The messages argument(s) provide text that should be included in the default
 // merge commit message (separated by blank lines).
-func (repo *GitRepo) MergeRef(ref string, fastForward bool, messages ...string) error {
+func (repo *GitRepo) MergeRef(ref string, fastForward, sign bool, messages ...string) error {
 	args := []string{"merge"}
 	if fastForward {
 		args = append(args, "--ff", "--ff-only")
 	} else {
 		args = append(args, "--no-ff")
+	}
+	if sign {
+		args = append(args, "-S")
 	}
 	if len(messages) > 0 {
 		commitMessage := strings.Join(messages, "\n\n")
@@ -385,7 +388,10 @@ func (repo *GitRepo) MergeRef(ref string, fastForward bool, messages ...string) 
 }
 
 // RebaseRef rebases the current ref onto the given one.
-func (repo *GitRepo) RebaseRef(ref string) error {
+func (repo *GitRepo) RebaseRef(ref string, sign bool) error {
+	if sign {
+		return repo.runGitCommandInline("rebase", "-S", "-i", ref)
+	}
 	return repo.runGitCommandInline("rebase", "-i", ref)
 }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -419,7 +419,7 @@ func (r *mockRepoForTest) ArchiveRef(ref, archive string) error {
 //
 // The ref argument is the ref to merge, and fastForward indicates that the
 // current ref should only move forward, as opposed to creating a bubble merge.
-func (r *mockRepoForTest) MergeRef(ref string, fastForward bool, messages ...string) error {
+func (r *mockRepoForTest) MergeRef(ref string, fastForward, sign bool, messages ...string) error {
 	newCommitHash, err := r.resolveLocalRef(ref)
 	if err != nil {
 		return err
@@ -446,7 +446,7 @@ func (r *mockRepoForTest) MergeRef(ref string, fastForward bool, messages ...str
 }
 
 // RebaseRef rebases the current ref onto the given one.
-func (r *mockRepoForTest) RebaseRef(ref string) error {
+func (r *mockRepoForTest) RebaseRef(ref string, sign bool) error {
 	parentHash := r.Refs[ref]
 	origCommit, err := r.getCommit(r.Head)
 	if err != nil {
@@ -573,7 +573,15 @@ func (r *mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRe
 	return nil
 }
 
-func (repo *mockRepoForTest) MergeNotesAndArchive(remote, notesRefPattern,
+// MergeNotes merges in the remote's state of the archives reference into
+// the local repository's.
+func (repo *mockRepoForTest) MergeNotes(remote, notesRefPattern string) error {
+	return nil
+}
+
+// MergeArchives merges in the remote's state of the archives reference into
+// the local repository's.
+func (repo *mockRepoForTest) MergeArchives(remote,
 	archiveRefPattern string) error {
 	return nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -419,7 +419,7 @@ func (r *mockRepoForTest) ArchiveRef(ref, archive string) error {
 //
 // The ref argument is the ref to merge, and fastForward indicates that the
 // current ref should only move forward, as opposed to creating a bubble merge.
-func (r *mockRepoForTest) MergeRef(ref string, fastForward, sign bool, messages ...string) error {
+func (r *mockRepoForTest) MergeRef(ref string, fastForward bool, messages ...string) error {
 	newCommitHash, err := r.resolveLocalRef(ref)
 	if err != nil {
 		return err
@@ -445,8 +445,18 @@ func (r *mockRepoForTest) MergeRef(ref string, fastForward, sign bool, messages 
 	return nil
 }
 
+// MergeAndSignRef merges the given ref into the current one and signs the
+// merge.
+//
+// The ref argument is the ref to merge, and fastForward indicates that the
+// current ref should only move forward, as opposed to creating a bubble merge.
+func (r *mockRepoForTest) MergeAndSignRef(ref string, fastForward bool,
+	messages ...string) error {
+	return nil
+}
+
 // RebaseRef rebases the current ref onto the given one.
-func (r *mockRepoForTest) RebaseRef(ref string, sign bool) error {
+func (r *mockRepoForTest) RebaseRef(ref string) error {
 	parentHash := r.Refs[ref]
 	origCommit, err := r.getCommit(r.Head)
 	if err != nil {
@@ -465,6 +475,10 @@ func (r *mockRepoForTest) RebaseRef(ref string, sign bool) error {
 	}
 	return nil
 }
+
+// RebaseAndSignRef rebases the current ref onto the given one and signs the
+// result.
+func (r *mockRepoForTest) RebaseAndSignRef(ref string) error { return nil }
 
 // ListCommits returns the list of commits reachable from the given ref.
 //

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -572,3 +572,20 @@ func (r *mockRepoForTest) PushNotesAndArchive(remote, notesRefPattern, archiveRe
 func (r *mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error {
 	return nil
 }
+
+func (repo *mockRepoForTest) MergeNotesAndArchive(remote, notesRefPattern,
+	archiveRefPattern string) error {
+	return nil
+}
+
+// FetchAndReturnNewReviewHashes fetches the notes "branches" and then susses
+// out the IDs (the revision the review points to) of any new reviews, then
+// returns that list of IDs.
+//
+// This is accomplished by determining which files in the notes tree have
+// changed because the _names_ of these files correspond to the revisions they
+// point to.
+func (repo *mockRepoForTest) FetchAndReturnNewReviewHashes(remote, notesRefPattern,
+	archiveRefPattern string) ([]string, error) {
+	return nil, nil
+}

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -194,6 +194,12 @@ func (r *mockRepoForTest) GetRepoStateHash() (string, error) {
 // GetUserEmail returns the email address that the user has used to configure git.
 func (r *mockRepoForTest) GetUserEmail() (string, error) { return "user@example.com", nil }
 
+// GetUserSigningKey returns the key id the user has configured for
+// sigining git artifacts.
+func (r *mockRepoForTest) GetUserSigningKey() (string, error) {
+	return "gpgsig", nil
+}
+
 // GetCoreEditor returns the name of the editor that the user has used to configure git.
 func (r *mockRepoForTest) GetCoreEditor() (string, error) { return "vi", nil }
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -41,6 +41,10 @@ type Repo interface {
 	// GetUserEmail returns the email address that the user has used to configure git.
 	GetUserEmail() (string, error)
 
+	// GetUserSigningKey returns the key id the user has configured for
+	// sigining git artifacts.
+	GetUserSigningKey() (string, error)
+
 	// GetCoreEditor returns the name of the editor that the user has used to configure git.
 	GetCoreEditor() (string, error)
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -121,10 +121,23 @@ type Repo interface {
 	// current ref should only move forward, as opposed to creating a bubble merge.
 	// The messages argument(s) provide text that should be included in the default
 	// merge commit message (separated by blank lines).
-	MergeRef(ref string, fastForward, sign bool, messages ...string) error
+	MergeRef(ref string, fastForward bool, messages ...string) error
+
+	// MergeAndSignRef merges the given ref into the current one and signs the
+	// merge.
+	//
+	// The ref argument is the ref to merge, and fastForward indicates that the
+	// current ref should only move forward, as opposed to creating a bubble merge.
+	// The messages argument(s) provide text that should be included in the default
+	// merge commit message (separated by blank lines).
+	MergeAndSignRef(ref string, fastForward bool, messages ...string) error
 
 	// RebaseRef rebases the current ref onto the given one.
-	RebaseRef(ref string, sign bool) error
+	RebaseRef(ref string) error
+
+	// RebaseAndSignRef rebases the current ref onto the given one and signs
+	// the result.
+	RebaseAndSignRef(ref string) error
 
 	// ListCommits returns the list of commits reachable from the given ref.
 	//

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -189,4 +189,18 @@ type Repo interface {
 	// we merely ensure that their history graph includes every commit that we
 	// intend to keep.
 	PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
+
+	// MergeNotesAndArchive merges the notes and archives from `remote` into
+	// the local branch.
+	MergeNotesAndArchive(remote, notesRefPattern,
+		archiveRefPattern string) error
+
+	// FetchAndReturnNewReviewHashes fetches the notes "branches" and then
+	// susses out the IDs (the revision the review points to) of any new
+	// reviews, then returns that list of IDs.
+	//
+	// This is accomplished by determining which files in the notes tree have
+	// changed because the _names_ of these files correspond to the revisions
+	// they point to.
+	FetchAndReturnNewReviewHashes(remote, notesRefPattern, archiveRefPattern string) ([]string, error)
 }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -121,10 +121,10 @@ type Repo interface {
 	// current ref should only move forward, as opposed to creating a bubble merge.
 	// The messages argument(s) provide text that should be included in the default
 	// merge commit message (separated by blank lines).
-	MergeRef(ref string, fastForward bool, messages ...string) error
+	MergeRef(ref string, fastForward, sign bool, messages ...string) error
 
 	// RebaseRef rebases the current ref onto the given one.
-	RebaseRef(ref string) error
+	RebaseRef(ref string, sign bool) error
 
 	// ListCommits returns the list of commits reachable from the given ref.
 	//
@@ -190,10 +190,12 @@ type Repo interface {
 	// intend to keep.
 	PullNotesAndArchive(remote, notesRefPattern, archiveRefPattern string) error
 
-	// MergeNotesAndArchive merges the notes and archives from `remote` into
-	// the local branch.
-	MergeNotesAndArchive(remote, notesRefPattern,
-		archiveRefPattern string) error
+	// MergeNotes merges in the remote's state of the archives reference into
+	// the local repository's.
+	MergeNotes(remote, notesRefPattern string) error
+	// MergeArchives merges in the remote's state of the archives reference
+	// into the local repository's.
+	MergeArchives(remote, archiveRefPattern string) error
 
 	// FetchAndReturnNewReviewHashes fetches the notes "branches" and then
 	// susses out the IDs (the revision the review points to) of any new

--- a/review/comment/comment.go
+++ b/review/comment/comment.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/git-appraise/repository"
+	"github.com/google/git-appraise/review/gpg"
 )
 
 // Ref defines the git-notes ref that we expect to contain review comments.
@@ -118,6 +119,8 @@ type Comment struct {
 	Resolved *bool `json:"resolved,omitempty"`
 	// Version represents the version of the metadata format.
 	Version int `json:"v,omitempty"`
+
+	gpg.Sig
 }
 
 // New returns a new comment with the given description message.

--- a/review/gpg/signable.go
+++ b/review/gpg/signable.go
@@ -5,6 +5,7 @@ package gpg
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -71,7 +72,7 @@ func signContent(key string, content []byte) (*bytes.Buffer,
 
 // Verify verifies the signatures on the request and its comments with the
 // given key.
-func Verify(key string, s Signable) error {
+func Verify(s Signable) error {
 	// Retrieve the pointer.
 	sigPtr := s.Signature()
 	// Copy its contents.
@@ -117,10 +118,12 @@ func Verify(key string, s Signable) error {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("gpg", "-u", key, "--verify", sigFile.Name(),
-		contentFile.Name())
+	cmd := exec.Command("gpg", "--verify", sigFile.Name(), contentFile.Name())
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()
-	return err
+	if err != nil {
+		return fmt.Errorf("%s", stderr.String())
+	}
+	return nil
 }

--- a/review/gpg/signable.go
+++ b/review/gpg/signable.go
@@ -31,7 +31,7 @@ type Signable interface {
 
 // Signature is `Sig`'s implementation of `Signable`. Through this function, an
 // object which needs to implement `Signable` need only embed `Sig`
-// anonymously. See, e.g., review/equest.go.
+// anonymously. See, e.g., review/request.go.
 func (s *Sig) Signature() *string {
 	return &s.Sig
 }
@@ -78,6 +78,8 @@ func Verify(key string, s Signable) error {
 	sig := *sigPtr
 	// Overwrite the value with the placeholder.
 	*sigPtr = placeholder
+
+	defer func() { *sigPtr = sig }()
 
 	// 1. Marshal the content into JSON.
 	// 2. Write the signature and the content to temp files.

--- a/review/gpg/signable.go
+++ b/review/gpg/signable.go
@@ -1,0 +1,124 @@
+// Package gpg provides an interface and an abstraction with which to sign and
+// verify review requests and comments.
+package gpg
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+const placeholder = "gpgsig"
+
+// Sig provides an abstraction around shelling out to GPG to sign the
+// content it's given.
+type Sig struct {
+	// Sig holds an object's content's signature.
+	Sig string `json:"signature,omitempty"`
+}
+
+// Signable is an interfaces which provides the pointer to the signable
+// object's stringified signature.
+//
+// This pointer is used by `Sign` and `Verify` to replace its contents with
+// `placeholder` or the signature itself for the purposes of signing or
+// verifying.
+type Signable interface {
+	Signature() *string
+}
+
+// Signature is `Sig`'s implementation of `Signable`. Through this function, an
+// object which needs to implement `Signable` need only embed `Sig`
+// anonymously. See, e.g., review/equest.go.
+func (s *Sig) Signature() *string {
+	return &s.Sig
+}
+
+// Sign uses gpg to sign the contents of a request and deposit it into the
+// signature key of the request.
+func Sign(key string, s Signable) error {
+	// First we retrieve the pointer and write `placeholder` as its value.
+	sigPtr := s.Signature()
+	*sigPtr = placeholder
+
+	// Marshal the content and sign it.
+	content, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	sig, err := signContent(key, content)
+	if err != nil {
+		return err
+	}
+
+	// Write the signature as the new value at the pointer.
+	*sigPtr = sig.String()
+	return nil
+}
+
+func signContent(key string, content []byte) (*bytes.Buffer,
+	error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("gpg", "-u", key, "--detach-sign", "--armor")
+	cmd.Stdin = bytes.NewReader(content)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return &stdout, err
+}
+
+// Verify verifies the signatures on the request and its comments with the
+// given key.
+func Verify(key string, s Signable) error {
+	// Retrieve the pointer.
+	sigPtr := s.Signature()
+	// Copy its contents.
+	sig := *sigPtr
+	// Overwrite the value with the placeholder.
+	*sigPtr = placeholder
+
+	// 1. Marshal the content into JSON.
+	// 2. Write the signature and the content to temp files.
+	// 3. Use gpg to verify the signature.
+	content, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	sigFile, err := ioutil.TempFile("", "sig")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(sigFile.Name())
+	_, err = sigFile.Write([]byte(sig))
+	if err != nil {
+		return err
+	}
+	err = sigFile.Close()
+	if err != nil {
+		return err
+	}
+
+	contentFile, err := ioutil.TempFile("", "content")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(contentFile.Name())
+	_, err = contentFile.Write(content)
+	if err != nil {
+		return err
+	}
+	err = contentFile.Close()
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("gpg", "-u", key, "--verify", sigFile.Name(),
+		contentFile.Name())
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	return err
+}

--- a/review/request/request.go
+++ b/review/request/request.go
@@ -19,9 +19,11 @@ package request
 
 import (
 	"encoding/json"
-	"github.com/google/git-appraise/repository"
 	"strconv"
 	"time"
+
+	"github.com/google/git-appraise/repository"
+	"github.com/google/git-appraise/review/gpg"
 )
 
 // Ref defines the git-notes ref that we expect to contain review requests.

--- a/review/request/request.go
+++ b/review/request/request.go
@@ -53,6 +53,8 @@ type Request struct {
 	// Alias stores a post-rebase commit ID for the review. This allows the tool
 	// to track the history of a review even if the commit history changes.
 	Alias string `json:"alias,omitempty"`
+
+	gpg.Sig
 }
 
 // New returns a new request.

--- a/review/review_test.go
+++ b/review/review_test.go
@@ -751,7 +751,7 @@ func TestRebase(t *testing.T) {
 	}
 
 	// Rebase the review and then confirm that it has been updated correctly.
-	if err := pendingReview.Rebase(true, false); err != nil {
+	if err := pendingReview.Rebase(true); err != nil {
 		t.Fatal(err)
 	}
 	reviewJSON, err := pendingReview.GetJSON()
@@ -785,7 +785,7 @@ func TestRebase(t *testing.T) {
 	if err := repo.SwitchToRef(pendingReview.Request.TargetRef); err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.MergeRef(pendingReview.Request.ReviewRef, true, false); err != nil {
+	if err := repo.MergeRef(pendingReview.Request.ReviewRef, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -825,7 +825,7 @@ func TestRebaseDetachedHead(t *testing.T) {
 	}
 
 	// Rebase the review and then confirm that it has been updated correctly.
-	if err := pendingReview.Rebase(true, false); err != nil {
+	if err := pendingReview.Rebase(true); err != nil {
 		t.Fatal(err)
 	}
 	headRef, err := repo.GetHeadRef()
@@ -851,7 +851,7 @@ func TestRebaseDetachedHead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.MergeRef(reviewHead, true, false); err != nil {
+	if err := repo.MergeRef(reviewHead, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/review/review_test.go
+++ b/review/review_test.go
@@ -751,7 +751,7 @@ func TestRebase(t *testing.T) {
 	}
 
 	// Rebase the review and then confirm that it has been updated correctly.
-	if err := pendingReview.Rebase(true); err != nil {
+	if err := pendingReview.Rebase(true, false); err != nil {
 		t.Fatal(err)
 	}
 	reviewJSON, err := pendingReview.GetJSON()
@@ -785,7 +785,7 @@ func TestRebase(t *testing.T) {
 	if err := repo.SwitchToRef(pendingReview.Request.TargetRef); err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.MergeRef(pendingReview.Request.ReviewRef, true); err != nil {
+	if err := repo.MergeRef(pendingReview.Request.ReviewRef, true, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -825,7 +825,7 @@ func TestRebaseDetachedHead(t *testing.T) {
 	}
 
 	// Rebase the review and then confirm that it has been updated correctly.
-	if err := pendingReview.Rebase(true); err != nil {
+	if err := pendingReview.Rebase(true, false); err != nil {
 		t.Fatal(err)
 	}
 	headRef, err := repo.GetHeadRef()
@@ -851,7 +851,7 @@ func TestRebaseDetachedHead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.MergeRef(reviewHead, true); err != nil {
+	if err := repo.MergeRef(reviewHead, true, false); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Addresses #89 

Hey there!

Here's my work so far w.r.t. implementing signing and verification. As it stands now, signing is available for both requests and acceptances, and we can verify those at `pull` time. I wanted to share now to see if there were any major contentions with the path I've gone down before I went through the rote repetition of adding signing functionality to the other comment-based commands.

Cheers!