### PR TITLE
Cleanup and generalize the API for low-level repository operations.

### DIFF
--- a/.github/workflows/mirror-pull-requests.yaml
+++ b/.github/workflows/mirror-pull-requests.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Fetch upstream refs
         run: |
-          git fetch origin '+refs/heads/*:refs/heads/*'
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
           git fetch origin '+refs/tags/*:refs/tags/*'
           git fetch origin '+refs/pull/*:refs/pull/*'
 

--- a/.github/workflows/mirror-pull-requests.yaml
+++ b/.github/workflows/mirror-pull-requests.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Fetch upstream refs
         run: |
-          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin '+refs/heads/*:refs/heads/*'
           git fetch origin '+refs/tags/*:refs/tags/*'
           git fetch origin '+refs/pull/*:refs/pull/*'
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -228,6 +229,11 @@ func (r *mockRepoForTest) HasRef(ref string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// HasObject reports whether or not the repo contains an object with the given hash
+func (r *mockRepoForTest) HasObject(hash string) (bool, error) {
+	return false, errors.New("Not implemented")
 }
 
 // VerifyCommit verifies that the supplied hash points to a known commit.
@@ -525,12 +531,12 @@ func (r *mockRepoForTest) ListCommitsBetween(from, to string) ([]string, error) 
 }
 
 // StoreBlob writes the given file to the repository and returns its hash.
-func (r *mockRepoForTest) StoreBlob(b *Blob) (string, error) {
+func (r *mockRepoForTest) StoreBlob(contents string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
 // StoreTree writes the given file tree to the repository and returns its hash.
-func (r *mockRepoForTest) StoreTree(t *Tree) (string, error) {
+func (r *mockRepoForTest) StoreTree(contents map[string]TreeChild) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -222,6 +222,14 @@ func (r *mockRepoForTest) resolveLocalRef(ref string) (string, error) {
 	return "", fmt.Errorf("The ref %q does not exist", ref)
 }
 
+// HasRef checks whether the specified ref exists in the repo.
+func (r *mockRepoForTest) HasRef(ref string) (bool, error) {
+	if _, ok := r.Refs[ref]; !ok {
+		return false, nil
+	}
+	return true, nil
+}
+
 // VerifyCommit verifies that the supplied hash points to a known commit.
 func (r *mockRepoForTest) VerifyCommit(hash string) error {
 	if _, ok := r.Commits[hash]; !ok {
@@ -516,6 +524,37 @@ func (r *mockRepoForTest) ListCommitsBetween(from, to string) ([]string, error) 
 	return commits, nil
 }
 
+// StoreBlob writes the given file to the repository and returns its hash.
+func (r *mockRepoForTest) StoreBlob(b *Blob) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// StoreTree writes the given file tree to the repository and returns its hash.
+func (r *mockRepoForTest) StoreTree(t *Tree) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// ReadTree reads the file tree pointed to by the given ref or hash from the repository.
+func (r *mockRepoForTest) ReadTree(ref string) (*Tree, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// CreateCommit creates a commit object and returns its hash.
+func (r *mockRepoForTest) CreateCommit(t *Tree, parents []string, message string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// CreateCommitFromTreeHash creates a commit object and returns its hash.
+func (r *mockRepoForTest) CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// SetRef sets the commit pointed to by the specified ref to `newCommitHash`,
+// iff the ref currently points `previousCommitHash`.
+func (r *mockRepoForTest) SetRef(ref, newCommitHash, previousCommitHash string) error {
+	return fmt.Errorf("not implemented")
+}
+
 // GetNotes reads the notes from the given ref that annotate the given revision.
 func (r *mockRepoForTest) GetNotes(notesRef, revision string) []Note {
 	notesText := r.Notes[notesRef][revision]
@@ -558,6 +597,14 @@ func (r *mockRepoForTest) ListNotedRevisions(notesRef string) []string {
 	return revisions
 }
 
+// Remotes returns a list of the remotes.
+func (r *mockRepoForTest) Remotes() ([]string, error) {
+	return []string{"origin"}, nil
+}
+
+// Fetch fetches from the given remote using the supplied refspecs.
+func (r *mockRepoForTest) Fetch(remote string, fetchSpecs []string) error { return nil }
+
 // PushNotes pushes git notes to a remote repo.
 func (r *mockRepoForTest) PushNotes(remote, notesRefPattern string) error { return nil }
 
@@ -589,14 +636,13 @@ func (r *mockRepoForTest) PullNotesAndArchive(remote, notesRefPattern, archiveRe
 
 // MergeNotes merges in the remote's state of the archives reference into
 // the local repository's.
-func (repo *mockRepoForTest) MergeNotes(remote, notesRefPattern string) error {
+func (r *mockRepoForTest) MergeNotes(remote, notesRefPattern string) error {
 	return nil
 }
 
 // MergeArchives merges in the remote's state of the archives reference into
 // the local repository's.
-func (repo *mockRepoForTest) MergeArchives(remote,
-	archiveRefPattern string) error {
+func (r *mockRepoForTest) MergeArchives(remote, archiveRefPattern string) error {
 	return nil
 }
 
@@ -607,7 +653,11 @@ func (repo *mockRepoForTest) MergeArchives(remote,
 // This is accomplished by determining which files in the notes tree have
 // changed because the _names_ of these files correspond to the revisions they
 // point to.
-func (repo *mockRepoForTest) FetchAndReturnNewReviewHashes(remote, notesRefPattern,
-	archiveRefPattern string) ([]string, error) {
+func (r *mockRepoForTest) FetchAndReturnNewReviewHashes(remote, notesRefPattern string, devtoolsRefPatterns ...string) ([]string, error) {
 	return nil, nil
+}
+
+// Push pushes the given refs to a remote repo.
+func (r *mockRepoForTest) Push(remote string, refPattern ...string) error {
+	return nil
 }

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -540,12 +540,12 @@ func (r *mockRepoForTest) ReadTree(ref string) (*Tree, error) {
 }
 
 // CreateCommit creates a commit object and returns its hash.
-func (r *mockRepoForTest) CreateCommit(t *Tree, parents []string, message string) (string, error) {
+func (r *mockRepoForTest) CreateCommit(details *CommitDetails) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-// CreateCommitFromTreeHash creates a commit object and returns its hash.
-func (r *mockRepoForTest) CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error) {
+// CreateCommitWithTree creates a commit object with the given tree and returns its hash.
+func (r *mockRepoForTest) CreateCommitWithTree(details *CommitDetails, t *Tree) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -609,7 +609,7 @@ func (r *mockRepoForTest) Remotes() ([]string, error) {
 }
 
 // Fetch fetches from the given remote using the supplied refspecs.
-func (r *mockRepoForTest) Fetch(remote string, fetchSpecs []string) error { return nil }
+func (r *mockRepoForTest) Fetch(remote string, refspecs ...string) error { return nil }
 
 // PushNotes pushes git notes to a remote repo.
 func (r *mockRepoForTest) PushNotes(remote, notesRefPattern string) error { return nil }

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -34,6 +34,7 @@ func (n Note) Hash() string {
 type CommitDetails struct {
 	Author         string   `json:"author,omitempty"`
 	AuthorEmail    string   `json:"authorEmail,omitempty"`
+	AuthorTime     string   `json:"authorTime,omitempty"`
 	Committer      string   `json:"committer,omitempty"`
 	CommitterEmail string   `json:"committerEmail,omitempty"`
 	Tree           string   `json:"tree,omitempty"`
@@ -234,10 +235,10 @@ type Repo interface {
 	ReadTree(ref string) (*Tree, error)
 
 	// CreateCommit creates a commit object and returns its hash.
-	CreateCommit(t *Tree, parents []string, message string) (string, error)
+	CreateCommit(details *CommitDetails) (string, error)
 
-	// CreateCommitFromTreeHash creates a commit object and returns its hash.
-	CreateCommitFromTreeHash(treeHash string, parents []string, message string) (string, error)
+	// CreateCommitWithTree creates a commit object with the given tree and returns its hash.
+	CreateCommitWithTree(details *CommitDetails, t *Tree) (string, error)
 
 	// SetRef sets the commit pointed to by the specified ref to `newCommitHash`,
 	// iff the ref currently points `previousCommitHash`.

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -313,7 +313,7 @@ type Repo interface {
 	Remotes() ([]string, error)
 
 	// Fetch fetches from the given remote using the supplied refspecs.
-	Fetch(remote string, fetchSpecs []string) error
+	Fetch(remote string, refspecs ...string) error
 
 	// PushNotes pushes git notes to a remote repo.
 	PushNotes(remote, notesRefPattern string) error

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -47,15 +47,25 @@ type TreeChild interface {
 	// Type returns the type of the child object (e.g. "blob" vs. "tree").
 	Type() string
 
-	// Store writes the object to the given repository and returns its hash.
+	// Store writes the object to the repository and returns its hash.
 	Store(repo Repo) (string, error)
 }
 
 // Blob represents a (non-directory) file stored in a repository.
+//
+// Blob objects are immutable.
 type Blob struct {
-	Contents string
+	savedHashes map[Repo]string
+	contents    string
+}
 
-	savedHash string
+// NewBlob returns a new *Blob object tied to the given repo with the given contents.
+func NewBlob(contents string) *Blob {
+	savedHashes := make(map[Repo]string)
+	return &Blob{
+		savedHashes: savedHashes,
+		contents:    contents,
+	}
 }
 
 func (b *Blob) Type() string {
@@ -63,17 +73,40 @@ func (b *Blob) Type() string {
 }
 
 func (b *Blob) Store(repo Repo) (string, error) {
-	return repo.StoreBlob(b)
+	if savedHash := b.savedHashes[repo]; savedHash != "" {
+		return savedHash, nil
+	}
+	savedHash, err := repo.StoreBlob(b.Contents())
+	if err == nil && savedHash != "" {
+		b.savedHashes[repo] = savedHash
+	}
+	return savedHash, nil
+}
+
+// Contents returns the contents of the blob
+func (b *Blob) Contents() string {
+	return b.contents
 }
 
 // Tree represents a directory stored in a repository.
+//
+// Tree objects are immutable.
 type Tree struct {
-	contents  map[string]TreeChild
-	savedHash string
+	savedHashes map[Repo]string
+	contents    map[string]TreeChild
 }
 
-func NewTree() *Tree {
-	return &Tree{contents: make(map[string]TreeChild)}
+// NewTree constructs a new *Tree object tied to the given repo with the given contents.
+func NewTree(contents map[string]TreeChild) *Tree {
+	immutableContents := make(map[string]TreeChild)
+	for k, v := range contents {
+		immutableContents[k] = v
+	}
+	savedHashes := make(map[Repo]string)
+	return &Tree{
+		savedHashes: savedHashes,
+		contents:    immutableContents,
+	}
 }
 
 func (t *Tree) Type() string {
@@ -81,13 +114,26 @@ func (t *Tree) Type() string {
 }
 
 func (t *Tree) Store(repo Repo) (string, error) {
-	return repo.StoreTree(t)
+	if savedHash := t.savedHashes[repo]; savedHash != "" {
+		return savedHash, nil
+	}
+	savedHash, err := repo.StoreTree(t.Contents())
+	if err == nil && savedHash != "" {
+		t.savedHashes[repo] = savedHash
+	}
+	return savedHash, nil
 }
 
+// Contents returns a map of the child elements of the tree.
+//
+// The returned map is mutable, but changes made to it have no
+// effect on the underly Tree object.
 func (t *Tree) Contents() map[string]TreeChild {
-	// Since the returned contents are mutable, we have to assume the hash could change.
-	t.savedHash = ""
-	return t.contents
+	result := make(map[string]TreeChild)
+	for k, v := range t.contents {
+		result[k] = v
+	}
+	return result
 }
 
 // Repo represents a source code repository.
@@ -116,6 +162,9 @@ type Repo interface {
 
 	// HasRef checks whether the specified ref exists in the repo.
 	HasRef(ref string) (bool, error)
+
+	// HasObject returns whether or not the repo contains an object with the given hash.
+	HasObject(hash string) (bool, error)
 
 	// VerifyCommit verifies that the supplied hash points to a known commit.
 	VerifyCommit(hash string) error
@@ -225,11 +274,11 @@ type Repo interface {
 	// The generated list is in chronological order (with the oldest commit first).
 	ListCommitsBetween(from, to string) ([]string, error)
 
-	// StoreBlob writes the given file to the repository and returns its hash.
-	StoreBlob(b *Blob) (string, error)
+	// StoreBlob writes the given file contents to the repository and returns its hash.
+	StoreBlob(contents string) (string, error)
 
-	// StoreTree writes the given file tree to the repository and returns its hash.
-	StoreTree(t *Tree) (string, error)
+	// StoreTree writes the given file tree contents to the repository and returns its hash.
+	StoreTree(contents map[string]TreeChild) (string, error)
 
 	// ReadTree reads the file tree pointed to by the given ref or hash from the repository.
 	ReadTree(ref string) (*Tree, error)


### PR DESCRIPTION
This change cleans up the API for low-level repository operations
in the following ways:

1. Introduce more generic operations on the underlying repository
   DAG objects (i.e. blobs, trees, commits, and refs).
2. Fix a bug in the code for merging archives where we did not
   check if the local archives ref existed before trying to
   resolve it.

Previously, the API exposed by the `repository` interface was very
tailored to the tasks that the git-appraise needed to perform for
code reviews. That meant that adding new features which used the
repository in slightly different ways would require rather large
changes to the repository interface.

Under the new API, any feature that simply relies upon the
features of git should be able to use the API without changes.

This was originally part of the pull request to add support for
forks, but is now being split off into a stand-alone pull request
so that it can be reviewed in isolation, and so that it is
available for other work like the proposed change to support
detached comments (#97).

The bug-fix for the archives issue is being included in here
because the refactoring to clean up the repository code is what
made us catch the underlying bug. The issue with that bug is that
we tried to use a single command ('git show') to both check if
the local archives ref (`refs/devtools/archives/reviews`) exists
and to resolve what commit it points to. However, that command
returns an error if the ref does not exist.

This change fixes it by including an explicit check to see if
the ref exists before trying to resolve it.