### PR TITLE
Make the PR-mirroring workflow use the entire history of the current branch

### DIFF
--- a/.github/workflows/mirror-pull-requests.yaml
+++ b/.github/workflows/mirror-pull-requests.yaml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Fetch upstream refs
         run: |
+          git fetch origin --unshallow
           git fetch origin '+refs/heads/*:refs/remotes/origin/*'
           git fetch origin '+refs/heads/master:refs/heads/master' || git pull
           git fetch origin '+refs/tags/*:refs/tags/*'


### PR DESCRIPTION
The default behavior of the GitHub workflow is to only fetch the last
commit of the current branch (resulting in a shallow repository).

This causes issues for the workflow to mirror pull request metadata
into git-notes, as the full history of the repository is necessary
in order for that to work.

This change fixes that by modifying the local repository to no longer
be a shallow clone.