### PR TITLE
Require `git` to be run from a trusted path

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"sort"
 	"strconv"
 	"strings"


### PR DESCRIPTION
On Windows, the current working directory is searched for a matching executable before the rest of the user's path.

This causes a potential issue where running `git appraise` from within a directory that has an executable file matching the command `git` will cause that (untrusted) file to be invoked instead of the expected `git` executable when `git-appraise` attempts to shell out to `git`.

This change prevents that by using the new `execabs` package instead of `os/exec`. With this change, that scenario would cause `git appraise` to report an error rather than invoking the wrong `git` binary.

More background on the related issue [here](https://blog.golang.org/path-security)