### PR TITLE
Add a github action to build and test

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,19 @@
+on: [push, pull_request]
+name: Build and Test
+env:
+  GO111MODULE: "off"
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.18.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - uses: actions/checkout@v3
+    - run: |
+        go build ./...
+        go test -v ./...

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,7 +1,5 @@
 on: [push, pull_request]
 name: Build and Test
-env:
-  GO111MODULE: "off"
 jobs:
   test:
     strategy:

--- a/.github/workflows/mirror-pull-requests.yaml
+++ b/.github/workflows/mirror-pull-requests.yaml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup go modules
         run: |
-          export GO111MODULE=on
-          go mod init workflow || true 
           go get github.com/google/git-appraise/git-appraise
           go get github.com/google/git-pull-request-mirror/batch
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/google/git-appraise
+
+go 1.18
+
+require golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 h1:QyVthZKMsyaQwBTJE04jdNN0Pp5Fn9Qga0mrgxyERQM=
+golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
The new GitHub action replaces the old Travis CI-based build and test.

This also sets up the `go.mod` and `go.sum` files which was necessary to (easily) get the build/test working.

Fixes #104