### PR TITLE
Look at the current reviewRef when submitting

### DIFF
--- a/commands/submit.go
+++ b/commands/submit.go
@@ -78,8 +78,8 @@ func submitReview(repo repository.Repo, args []string) error {
 	if err := repo.VerifyGitRef(target); err != nil {
 		return err
 	}
-	source, err := r.GetHeadCommit()
-	if err != nil {
+	source := r.Request.ReviewRef
+	if err := repo.VerifyGitRef(source); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When a review has been rebased and then force pushed to update a review,
for example to fix review comments. It can become impossible to submit
with the error message:

Refusing to submit a non-fast-forward review. First merge the target
ref.

this even if the review ref is a ancestor of the target ref and the
merge should been a fast forward merge. This is because the check for
appraise submit is done against the first commit sha1 that was used and
not for the actually reviewRef that will be merged. This fixes that.